### PR TITLE
Strings should not be auto-approved by default on file upload 

### DIFF
--- a/lib/FileUploadParameterBuilder.php
+++ b/lib/FileUploadParameterBuilder.php
@@ -28,7 +28,7 @@ class FileUploadParameterBuilder {
    *
    * @var bool
    */
-  protected $_approved = TRUE;
+  protected $_approved = FALSE;
 
   /**
    * api locales to approve


### PR DESCRIPTION
See: https://docs.smartling.com/display/docs/Files+API