### PR TITLE
Added user agent extension

### DIFF
--- a/src/AuditLog/Params/CreateRecordParameters.php
+++ b/src/AuditLog/Params/CreateRecordParameters.php
@@ -90,7 +90,7 @@ class CreateRecordParameters extends BaseParameters
     }
 
     public function setTranslationJobAuthorize($translationJobAuthorize) {
-        $this->set('translationJobAuthorize', $translationJobAuthorize);
+        $this->set('translationJobAuthorize', (bool) $translationJobAuthorize);
 
         return $this;
     }

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -23,7 +23,9 @@ abstract class BaseApiAbstract
 
     const CLIENT_LIB_ID_SDK = 'smartling-api-sdk-php';
 
-    const CLIENT_LIB_ID_VERSION = '3.5.3';
+    const CLIENT_LIB_ID_VERSION = '3.6.2';
+
+    const CLIENT_USER_AGENT_EXTENSION = '(no extensions)';
 
     const HTTP_METHOD_GET = 'get';
 
@@ -36,6 +38,24 @@ abstract class BaseApiAbstract
     private static $currentClientId = self::CLIENT_LIB_ID_SDK;
 
     private static $currentClientVersion = self::CLIENT_LIB_ID_VERSION;
+
+    private static $currentClientUserAgentExtension = self::CLIENT_USER_AGENT_EXTENSION;
+
+    /**
+     * @param string $currentClientUserAgentExtension
+     */
+    public static function setCurrentClientUserAgentExtension($currentClientUserAgentExtension)
+    {
+        self::$currentClientUserAgentExtension = $currentClientUserAgentExtension;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getCurrentClientUserAgentExtension()
+    {
+        return self::$currentClientUserAgentExtension;
+    }
 
     /**
      * @return string
@@ -223,10 +243,11 @@ abstract class BaseApiAbstract
                 'debug' => $debug,
                 'headers' => [
                     'User-Agent' => vsprintf(
-                        '%s/%s %s',
+                        '%s/%s %s %s',
                         [
                             self::getCurrentClientId(),
                             self::getCurrentClientVersion(),
+                            self::getCurrentClientUserAgentExtension(),
                             GuzzleHttp\default_user_agent()
                         ]
                     ),

--- a/tests/unit/AuditLogApiTest.php
+++ b/tests/unit/AuditLogApiTest.php
@@ -31,7 +31,7 @@ class AuditLogApiTest extends ApiTestAbstract
             ->setTranslationJobUid("smartling_job_uid")
             ->setTranslationJobName("smartling_job_name")
             ->setTranslationJobDueDate("smartling_job_due_date")
-            ->setTranslationJobAuthorize(true)
+            ->setTranslationJobAuthorize(1)
             ->setBatchUid("batch_uid")
             ->setDescription("description")
             ->setClientUserId("user_id")

--- a/tests/unit/BaseApiAbstractTest.php
+++ b/tests/unit/BaseApiAbstractTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Smartling\Tests\Unit;
+
+use Smartling\BaseApiAbstract;
+use Smartling\File\FileApi;
+
+class BaseApiAbstractTest extends ApiTestAbstract
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Restore user agent specific static values.
+        BaseApiAbstract::setCurrentClientId(BaseApiAbstract::CLIENT_LIB_ID_SDK);
+        BaseApiAbstract::setCurrentClientVersion(BaseApiAbstract::CLIENT_LIB_ID_VERSION);
+        BaseApiAbstract::setCurrentClientUserAgentExtension(BaseApiAbstract::CLIENT_USER_AGENT_EXTENSION);
+    }
+
+    /**
+     * @covers \Smartling\Api\BaseApiAbstract::setCurrentUserAgentExtension()
+     */
+    public function testNoUserAgentExtensions()
+    {
+        $instance = FileApi::create($this->authProvider, 'test');
+        $http_client = $this->invokeMethod($instance, 'getHttpClient');
+
+        $this->assertTrue(
+            strpos(
+                $http_client->getConfig()['headers']['User-Agent'],
+                'smartling-api-sdk-php/3.6.2 (no extensions) GuzzleHttp/6'
+            ) !== FALSE
+        );
+    }
+
+    /**
+     * Test custom client id and version in user agent.
+     */
+    public function testCurrentClientIdAndVersionSpecifiedUserAgentExtensionNotSpecified()
+    {
+        BaseApiAbstract::setCurrentClientId('php-connector');
+        BaseApiAbstract::setCurrentClientVersion('1.2.3');
+
+        $instance = FileApi::create($this->authProvider, 'test');
+        $http_client = $this->invokeMethod($instance, 'getHttpClient');
+
+        $this->assertTrue(
+            strpos(
+                $http_client->getConfig()['headers']['User-Agent'],
+                'php-connector/1.2.3 (no extensions) GuzzleHttp/6'
+            ) !== FALSE
+        );
+    }
+
+    /**
+     * @covers \Smartling\Api\BaseApiAbstract::setCurrentUserAgentExtension()
+     */
+    public function testClientIdAndClientVersionAndUserAgentExtensionsSpecified()
+    {
+        BaseApiAbstract::setCurrentClientId('php-connector');
+        BaseApiAbstract::setCurrentClientVersion('1.2.3');
+        BaseApiAbstract::setCurrentClientUserAgentExtension('dependency-1/version-1 dependency-2/version-2');
+
+        $instance = FileApi::create($this->authProvider, 'test');
+        $http_client = $this->invokeMethod($instance, 'getHttpClient');
+
+        $this->assertTrue(
+            strpos(
+                $http_client->getConfig()['headers']['User-Agent'],
+                'php-connector/1.2.3 dependency-1/version-1 dependency-2/version-2 GuzzleHttp/6'
+            ) !== FALSE
+        );
+    }
+}

--- a/tests/unit/BaseApiAbstractTest.php
+++ b/tests/unit/BaseApiAbstractTest.php
@@ -18,7 +18,7 @@ class BaseApiAbstractTest extends ApiTestAbstract
     }
 
     /**
-     * @covers \Smartling\Api\BaseApiAbstract::setCurrentUserAgentExtension()
+     * Test default user agent.
      */
     public function testNoUserAgentExtensions()
     {
@@ -53,7 +53,7 @@ class BaseApiAbstractTest extends ApiTestAbstract
     }
 
     /**
-     * @covers \Smartling\Api\BaseApiAbstract::setCurrentUserAgentExtension()
+     * Test custom client id, version and extension in user agent.
      */
     public function testClientIdAndClientVersionAndUserAgentExtensionsSpecified()
     {

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -119,7 +119,7 @@ class FileApiTest extends ApiTestAbstract
                     ],
                     [
                         'name' => 'smartling.client_lib_id',
-                        'contents' => '{"client":"smartling-api-sdk-php","version":"3.5.3"}',
+                        'contents' => '{"client":"smartling-api-sdk-php","version":"3.6.2"}',
                     ],
                     [
                         'name' => 'localeIdsToAuthorize[]',


### PR DESCRIPTION
1. Added possibility to extend user agent with custom values (needed for specifying connectors dependencies).
2. Fixed issue with `AuditLogApi` (ES index has `translationJobAuthorize` as a `bool` so we need to force cast the value passed to `setTranslationJobAuthorize` to `bool`).