### PR TITLE
 Added contextMatchingInstrumented retrievalType

### DIFF
--- a/src/File/Params/DownloadFileParameters.php
+++ b/src/File/Params/DownloadFileParameters.php
@@ -19,6 +19,8 @@ class DownloadFileParameters extends BaseParameters
 
     const RETRIEVAL_TYPE_PSEUDO = 'pseudo';
 
+    const RETRIEVAL_TYPE_CONTEXT_MATCHING_INSTRUMENTED = 'contextMatchingInstrumented';
+
     /**
      * @param string $retrievalType
      *
@@ -34,6 +36,7 @@ class DownloadFileParameters extends BaseParameters
                 self::RETRIEVAL_TYPE_PENDING,
                 self::RETRIEVAL_TYPE_PUBLISHED,
                 self::RETRIEVAL_TYPE_PSEUDO,
+                self::RETRIEVAL_TYPE_CONTEXT_MATCHING_INSTRUMENTED
             ],
             true
         );

--- a/src/File/Params/DownloadFileParameters.php
+++ b/src/File/Params/DownloadFileParameters.php
@@ -30,7 +30,7 @@ class DownloadFileParameters extends BaseParameters
     public function setRetrievalType($retrievalType)
     {
 
-        $validRetrivalType = in_array(
+        $validRetrievalType = in_array(
             $retrievalType,
             [
                 self::RETRIEVAL_TYPE_PENDING,
@@ -41,7 +41,7 @@ class DownloadFileParameters extends BaseParameters
             true
         );
 
-        if (!$validRetrivalType) {
+        if (!$validRetrievalType) {
             throw new SmartlingApiException('Unknown retrieval type: ' . var_export($retrievalType, true));
         }
 


### PR DESCRIPTION
This PR adds an additional parameter to the `File\Params\DownloadFileParameters` class called "contextMatchingInstrumented" for the `retrievalType` query parameter [mentioned in the File API docs](https://api-reference.smartling.com/#operation/downloadTranslatedFileSingleLocale).

This parameter does not currently exist in this SDK.