### PR TITLE
Query string array fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
   - travis_retry composer self-update

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -316,7 +316,7 @@ abstract class BaseApiAbstract
                 foreach ($parameters as $key => $value) {
                     if (is_array($value)) {
                         foreach ($value as $item) {
-                            $queryStringParts[] = "$key" . "[]=$item";
+                            $queryStringParts[] = "$key=$item";
                         }
                     } else {
                         $queryStringParts[] = "$key=$value";

--- a/src/File/FileApi.php
+++ b/src/File/FileApi.php
@@ -60,6 +60,44 @@ class FileApi extends BaseApiAbstract
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * FileAPI requires [] syntax for array values in query string.
+     */
+    protected function getDefaultRequestData($parametersType, $parameters, $auth = true, $httpErrors = false) {
+        $options = parent::getDefaultRequestData($parametersType, $parameters, $auth, $httpErrors);
+        $queryStringAsStringNeeded = false;
+
+        if ($parametersType == 'query') {
+            foreach ($parameters as $key => $value) {
+                if (is_array($value)) {
+                    $queryStringAsStringNeeded = true;
+
+                    break;
+                }
+            }
+
+            if ($queryStringAsStringNeeded) {
+                $queryStringParts = [];
+
+                foreach ($parameters as $key => $value) {
+                    if (is_array($value)) {
+                        foreach ($value as $item) {
+                            $queryStringParts[] = "$key" . "[]=$item";
+                        }
+                    } else {
+                        $queryStringParts[] = "$key=$value";
+                    }
+                }
+
+                $options[$parametersType] = implode("&", $queryStringParts);
+            }
+        }
+
+        return $options;
+    }
+
+    /**
      * Uploads original source content to Smartling.
      *
      * @param string $realPath

--- a/tests/functional/FileApiFunctionalTest.php
+++ b/tests/functional/FileApiFunctionalTest.php
@@ -8,6 +8,7 @@ use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\File\FileApi;
 use Smartling\File\Params\DownloadFileParameters;
+use Smartling\File\Params\DownloadMultipleFilesParameters;
 use Smartling\File\Params\ListFilesParameters;
 
 /**
@@ -151,6 +152,45 @@ class FileApiFunctionalTest extends PHPUnit_Framework_TestCase
             $params = new DownloadFileParameters();
             $params->setRetrievalType($this->retrievalType);
             $result = $this->fileApi->downloadFile(self::FILE_NAME, $this->targetLocale, $params);
+
+            $this->assertInstanceOf(Stream::class, $result);
+        } catch (SmartlingApiException $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * Test for download all translations of file.
+     */
+    public function testFileApiDownloadAllTranslationsOfFile() {
+        try {
+            $params = new DownloadFileParameters();
+            $params->setRetrievalType($this->retrievalType);
+            $result = $this->fileApi->downloadAllTranslationsOfFile(self::FILE_NAME, $params);
+
+            $this->assertInstanceOf(Stream::class, $result);
+        } catch (SmartlingApiException $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * Test for download multiple translations of files.
+     */
+    public function testFileApiDownloadMultipleTranslationsOfFiles() {
+        try {
+            $params = new DownloadMultipleFilesParameters();
+            $params->setRetrievalType($this->retrievalType);
+            $params->setFileUris([
+                self::FILE_NAME
+            ]);
+            $params->setLocaleIds([
+                "fr",
+                "de"
+            ]);
+            $params->setLocaleMode(DownloadMultipleFilesParameters::LOCALE_MODE_LOCALE_IN_NAME_AND_PATH);
+            $params->setFileNameMode(DownloadMultipleFilesParameters::FILE_NAME_MODE_LOCALE_LAST);
+            $result = $this->fileApi->downloadMultipleTranslationsOfFiles($params);
 
             $this->assertInstanceOf(Stream::class, $result);
         } catch (SmartlingApiException $e) {

--- a/tests/functional/JobsApiFunctionalTest.php
+++ b/tests/functional/JobsApiFunctionalTest.php
@@ -9,6 +9,7 @@ use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\File\FileApi;
 use Smartling\Jobs\JobsApi;
+use Smartling\Jobs\JobStatus;
 use Smartling\Jobs\Params\AddFileToJobParameters;
 use Smartling\Jobs\Params\AddLocaleToJobParameters;
 use Smartling\Jobs\Params\CancelJobParameters;
@@ -133,7 +134,12 @@ class JobsApiFunctionalTest extends PHPUnit_Framework_TestCase
     public function testJobsApiListJobs()
     {
         try {
-            $result = $this->jobsApi->listJobs(new ListJobsParameters());
+            $params = new ListJobsParameters();
+            $params->setStatuses([
+                JobStatus::AWAITING_AUTHORIZATION,
+                JobStatus::IN_PROGRESS,
+            ]);
+            $result = $this->jobsApi->listJobs($params);
 
             $this->assertArrayHasKey('totalCount', $result);
             $this->assertArrayHasKey('items', $result);

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -329,7 +329,7 @@ class FileApiTest extends ApiTestAbstract
                     ]),
                 ],
                 'exceptions' => false,
-                'query' => 'retrievalType=pseudo&fileNameMode=LOCALE_LAST&localeMode=LOCALE_IN_NAME_AND_PATH&fileUris[]=test1.xml&fileUris[]=test2.xml&localeIds[]=fr&localeIds[]=de&includeOriginalStrings=1&zipFileName=zipFileName.zip',
+                'query' => 'retrievalType=pseudo&fileNameMode=LOCALE_LAST&localeMode=LOCALE_IN_NAME_AND_PATH&fileUris=test1.xml&fileUris=test2.xml&localeIds=fr&localeIds=de&includeOriginalStrings=1&zipFileName=zipFileName.zip',
             ])
             ->willReturn($this->responseMock);
 

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -329,7 +329,7 @@ class FileApiTest extends ApiTestAbstract
                     ]),
                 ],
                 'exceptions' => false,
-                'query' => 'retrievalType=pseudo&fileNameMode=LOCALE_LAST&localeMode=LOCALE_IN_NAME_AND_PATH&fileUris=test1.xml&fileUris=test2.xml&localeIds=fr&localeIds=de&includeOriginalStrings=1&zipFileName=zipFileName.zip',
+                'query' => 'retrievalType=pseudo&fileNameMode=LOCALE_LAST&localeMode=LOCALE_IN_NAME_AND_PATH&fileUris[]=test1.xml&fileUris[]=test2.xml&localeIds[]=fr&localeIds[]=de&includeOriginalStrings=1&zipFileName=zipFileName.zip',
             ])
             ->willReturn($this->responseMock);
 

--- a/tests/unit/JobsApiTest.php
+++ b/tests/unit/JobsApiTest.php
@@ -5,6 +5,7 @@ namespace Smartling\Tests\Unit;
 use DateTime;
 use DateTimeZone;
 use Smartling\Jobs\JobsApi;
+use Smartling\Jobs\JobStatus;
 use Smartling\Jobs\Params\AddFileToJobParameters;
 use Smartling\Jobs\Params\AddLocaleToJobParameters;
 use Smartling\Jobs\Params\CancelJobParameters;
@@ -188,7 +189,7 @@ class JobsApiTest extends ApiTestAbstract
     /**
      * @covers \Smartling\Jobs\JobsApi::listJobs
      */
-    public function testListJobs() {
+    public function testListJobsQueryAsArray() {
         $name = 'Test Job Name Updated';
         $limit = 1;
         $offset = 2;
@@ -218,6 +219,43 @@ class JobsApiTest extends ApiTestAbstract
                     'limit' => $limit,
                     'offset' => $offset,
                 ],
+            ])
+            ->willReturn($this->responseMock);
+
+        $this->object->listJobs($params);
+    }
+
+    /**
+     * @covers \Smartling\Jobs\JobsApi::listJobs
+     */
+    public function testListJobsQueryAsString() {
+        $limit = 1;
+        $offset = 2;
+        $params = new ListJobsParameters();
+        $params->setStatuses([
+            JobStatus::AWAITING_AUTHORIZATION,
+            JobStatus::IN_PROGRESS,
+        ]);
+        $params->setLimit($limit);
+        $params->setOffset($offset);
+        $endpointUrl = vsprintf('%s/%s/jobs', [
+            JobsApi::ENDPOINT_URL,
+            $this->projectId,
+        ]);
+
+        $this->client
+            ->expects(self::once())
+            ->method('request')
+            ->with('get', $endpointUrl, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'Authorization' => vsprintf('%s %s', [
+                        $this->authProvider->getTokenType(),
+                        $this->authProvider->getAccessToken(),
+                    ]),
+                ],
+                'exceptions' => FALSE,
+                'query' => "translationJobStatus[]=AWAITING_AUTHORIZATION&translationJobStatus[]=IN_PROGRESS&limit=1&offset=2"
             ])
             ->willReturn($this->responseMock);
 

--- a/tests/unit/JobsApiTest.php
+++ b/tests/unit/JobsApiTest.php
@@ -255,7 +255,7 @@ class JobsApiTest extends ApiTestAbstract
                     ]),
                 ],
                 'exceptions' => FALSE,
-                'query' => "translationJobStatus[]=AWAITING_AUTHORIZATION&translationJobStatus[]=IN_PROGRESS&limit=1&offset=2"
+                'query' => "translationJobStatus=AWAITING_AUTHORIZATION&translationJobStatus=IN_PROGRESS&limit=1&offset=2"
             ])
             ->willReturn($this->responseMock);
 


### PR DESCRIPTION
@dimitrystd for now, [this call to FileAPI](https://api-reference.smartling.com/#operation/downloadMultipleTranslatedFiles) will fail. This is because we decided to get rid of `[]` from all the requests (JobsAPI, FIleAPI, etc) in our sdk, but `FileAPI` still looks only for `fileUris[]` and `localeIds[]` parameters with `[]`. I've asked @maescomua if it's can be fixed in FileAPI.

UPDATED: is not being failed now since we decided to use different array value syntax in query strings for Jobs and FIle APIs