### PR TITLE
Support data:// protocol as content for context upload

### DIFF
--- a/src/Context/ContextApi.php
+++ b/src/Context/ContextApi.php
@@ -71,6 +71,8 @@ class ContextApi extends BaseApiAbstract implements Waitable
 
     /**
      * {@inheritdoc}
+     *
+     * @throws SmartlingApiException
      */
     protected function processBodyOptions($requestData = []) {
         $opts = parent::processBodyOptions($requestData);
@@ -80,6 +82,14 @@ class ContextApi extends BaseApiAbstract implements Waitable
             foreach ($opts['multipart'] as &$data) {
                 if (in_array($data['name'], $keys)) {
                     $data['contents'] = $this->readFile($data['contents']);
+
+                    if ($data['name'] === 'content' && substr($requestData['multipart']['content'], 0, 7) === 'data://') {
+                      if (!isset($requestData['multipart']['name'])) {
+                        throw new SmartlingApiException('When content is specified using the data:// protocol, name is a required request body field');
+                      }
+
+                      $data['filename'] = $requestData['multipart']['name'];
+                    }
                 }
 
                 if ($data['name'] == 'matchParams') {

--- a/tests/unit/ContextApiTest.php
+++ b/tests/unit/ContextApiTest.php
@@ -26,7 +26,7 @@ class ContextApiTest extends ApiTestAbstract
         $this->prepareContextApiMock();
     }
 
-    private function prepareContextApiMock()
+    private function prepareContextApiMock($stream = null)
     {
         $this->object = $this->getMockBuilder('Smartling\Context\ContextApi')
             ->setMethods(['readFile'])
@@ -40,7 +40,7 @@ class ContextApiTest extends ApiTestAbstract
 
         $this->object->expects(self::any())
             ->method('readFile')
-            ->willReturn($this->streamPlaceholder);
+            ->willReturn(is_null($stream) ? $this->streamPlaceholder : $stream);
 
         $this->invokeMethod(
             $this->object,
@@ -176,6 +176,81 @@ class ContextApiTest extends ApiTestAbstract
                 ],
             ])
             ->willReturn($this->responseMock);
+
+        $this->object->uploadAndMatchContext($params);
+    }
+
+    /**
+     * @covers \Smartling\Context\ContextApi::uploadAndMatchContext
+     */
+    public function testUploadAndMatchContextWithDataProtocol() {
+        $fileUri = './tests/resources/context.html';
+        $name = 'test_context.html';
+
+        $matchParams = new MatchContextParameters();
+        $matchParams->setContentFileUri($fileUri);
+
+        $params = new UploadContextParameters();
+        $params->setContent(sprintf('data://text/html;base64,%s', base64_encode(file_get_contents($fileUri))));
+        $params->setName($name);
+        $params->setMatchParams($matchParams);
+
+        $endpointUrl = vsprintf('%s/%s/contexts/upload-and-match-async', [
+            ContextApi::ENDPOINT_URL,
+            $this->projectId
+        ]);
+
+        $this->client
+            ->expects(self::once())
+            ->method('request')
+            ->with('post', $endpointUrl, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'Authorization' => vsprintf('%s %s', [
+                        $this->authProvider->getTokenType(),
+                        $this->authProvider->getAccessToken(),
+                    ]),
+                    'X-SL-Context-Source' => $this->invokeMethod($this->object, 'getXSLContextSourceHeader'),
+                ],
+                'exceptions' => FALSE,
+                'multipart' => [
+                    [
+                        'name' => 'content',
+                        'contents' => $this->streamPlaceholder,
+                        'filename' => $name,
+                    ],
+                    [
+                        'name' => 'name',
+                        'contents' => $name,
+                    ],
+                    [
+                        'name' => 'matchParams',
+                        'contents' => '{"contentFileUri":".\/tests\/resources\/context.html"}',
+                        'headers' => [
+                            'Content-Type' => 'application/json',
+                        ]
+                    ],
+                ],
+            ])
+            ->willReturn($this->responseMock);
+
+        $this->object->uploadAndMatchContext($params);
+    }
+    /**
+     * @covers \Smartling\Context\ContextApi::uploadAndMatchContext
+     *
+     * @expectedException \Smartling\Exceptions\SmartlingApiException
+     * @expectedExceptionMessage When content is specified using the data:// protocol, name is a required request body field
+     */
+    public function testUploadAndMatchContextWithDataProtocolFailsWhenNoNameSupplied() {
+        $fileUri = './tests/resources/context.html';
+
+        $matchParams = new MatchContextParameters();
+        $matchParams->setContentFileUri($fileUri);
+
+        $params = new UploadContextParameters();
+        $params->setContent(sprintf('data://text/html;base64,%s', base64_encode(file_get_contents($fileUri))));
+        $params->setMatchParams($matchParams);
 
         $this->object->uploadAndMatchContext($params);
     }

--- a/tests/unit/ContextApiTest.php
+++ b/tests/unit/ContextApiTest.php
@@ -26,7 +26,7 @@ class ContextApiTest extends ApiTestAbstract
         $this->prepareContextApiMock();
     }
 
-    private function prepareContextApiMock($stream = null)
+    private function prepareContextApiMock()
     {
         $this->object = $this->getMockBuilder('Smartling\Context\ContextApi')
             ->setMethods(['readFile'])
@@ -40,7 +40,7 @@ class ContextApiTest extends ApiTestAbstract
 
         $this->object->expects(self::any())
             ->method('readFile')
-            ->willReturn(is_null($stream) ? $this->streamPlaceholder : $stream);
+            ->willReturn($this->streamPlaceholder);
 
         $this->invokeMethod(
             $this->object,

--- a/tests/unit/ContextApiTest.php
+++ b/tests/unit/ContextApiTest.php
@@ -236,6 +236,7 @@ class ContextApiTest extends ApiTestAbstract
 
         $this->object->uploadAndMatchContext($params);
     }
+
     /**
      * @covers \Smartling\Context\ContextApi::uploadAndMatchContext
      *


### PR DESCRIPTION
In the process of trying to upload visual context without saving a local file we ran into an issue where the mime type of the content was failing to be determined correctly.
Came to realise that this was due to the fact that the stream that is created by `fopen` from a `data://` protocol string does not contain a filename and guzzle fails to determine the correct `content-type`, but they support reading the file name from a `filename` parameter in the same `multipart`.