### PR TITLE
Added localeWorkflows param to BatchApi::execute

### DIFF
--- a/examples/batch-example.php
+++ b/examples/batch-example.php
@@ -11,6 +11,7 @@
 
 use Smartling\Batch\BatchApi;
 use Smartling\Batch\Params\CreateBatchParameters;
+use Smartling\Batch\Params\ExecuteBatchParameters;
 use Smartling\File\Params\UploadFileParameters;
 
 $longOpts = [
@@ -128,10 +129,14 @@ function executeBatchDemo($authProvider, $projectId, $batchUid)
 
     $response = [];
     $batchApi = BatchApi::create($authProvider, $projectId);
+    $executeParameters = new ExecuteBatchParameters();
+    $executeParameters
+      ->addLocaleWorkflowPair('fr-FR', 'test_wf_uid_1')
+      ->addLocaleWorkflowPair('de-DE', 'test_wf_uid_2');
     $st = \microtime(true);
 
     try {
-        $response = $batchApi->executeBatch($batchUid);
+        $response = $batchApi->executeBatch($batchUid, $executeParameters);
     } catch (\Smartling\Exceptions\SmartlingApiException $e) {
         \var_dump($e->getErrors());
     }

--- a/src/Batch/BatchApi.php
+++ b/src/Batch/BatchApi.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 use Smartling\AuthApi\AuthApiInterface;
 use Smartling\BaseApiAbstract;
 use Smartling\Batch\Params\CreateBatchParameters;
+use Smartling\Batch\Params\ExecuteBatchParameters;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\File\Params\UploadFileParameters;
 
@@ -114,24 +115,19 @@ class BatchApi extends BaseApiAbstract
      * Execute batch.
      *
      * @param $batchUid
-     * @param array $localeWorkflows
+     * @param ExecuteBatchParameters $parameters
      *
      * @return bool
      *
      * @throws SmartlingApiException
      */
-    public function executeBatch($batchUid, array $localeWorkflows = [])
+    public function executeBatch($batchUid, ExecuteBatchParameters $parameters = null)
     {
         $endpoint = \vsprintf('batches/%s', [$batchUid]);
-        $params = [
+
+        $requestData = $this->getDefaultRequestData('json', [
           'action' => self::ACTION_EXECUTE,
-        ];
-
-        if ($localeWorkflows) {
-          $params['localeWorkflows'] = $localeWorkflows;
-        }
-
-        $requestData = $this->getDefaultRequestData('json', $params);
+        ] + (\is_null($parameters) ? [] : $parameters->exportToArray()));
 
         return $this->sendRequest($endpoint, $requestData, self::HTTP_METHOD_POST);
     }

--- a/src/Batch/BatchApi.php
+++ b/src/Batch/BatchApi.php
@@ -114,17 +114,24 @@ class BatchApi extends BaseApiAbstract
      * Execute batch.
      *
      * @param $batchUid
+     * @param array $localeWorkflows
      *
      * @return bool
      *
      * @throws SmartlingApiException
      */
-    public function executeBatch($batchUid)
+    public function executeBatch($batchUid, array $localeWorkflows = [])
     {
         $endpoint = \vsprintf('batches/%s', [$batchUid]);
-        $requestData = $this->getDefaultRequestData('json', [
+        $params = [
           'action' => self::ACTION_EXECUTE,
-        ]);
+        ];
+
+        if ($localeWorkflows) {
+          $params['localeWorkflows'] = $localeWorkflows;
+        }
+
+        $requestData = $this->getDefaultRequestData('json', $params);
 
         return $this->sendRequest($endpoint, $requestData, self::HTTP_METHOD_POST);
     }

--- a/src/Batch/Params/ExecuteBatchParameters.php
+++ b/src/Batch/Params/ExecuteBatchParameters.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Smartling\Batch\Params;
+
+use Smartling\Parameters\BaseParameters;
+
+/**
+ * Class ExecuteBatchParameters
+ *
+ * @package Smartling\Facade\Params
+ */
+class ExecuteBatchParameters extends BaseParameters
+{
+
+    /**
+     * @param string $targetLocaleId
+     * @param string $workflowUid
+     *
+     * @return $this
+     */
+    public function addLocaleWorkflowPair($targetLocaleId, $workflowUid) {
+
+      if (!\array_key_exists('localeWorkflows', $this->params)) {
+        $this->set('localeWorkflows', []);
+      }
+
+      $this->params['localeWorkflows'][] = [
+        'targetLocaleId' => $targetLocaleId,
+        'workflowUid' => $workflowUid,
+      ];
+
+      return $this;
+    }
+
+}

--- a/tests/unit/BatchApiTest.php
+++ b/tests/unit/BatchApiTest.php
@@ -3,6 +3,7 @@
 namespace Smartling\Tests\Unit;
 use Smartling\Batch\BatchApi;
 use Smartling\Batch\Params\CreateBatchParameters;
+use Smartling\Batch\Params\ExecuteBatchParameters;
 use Smartling\File\Params\UploadFileParameters;
 
 /**
@@ -178,6 +179,11 @@ class BatchApiTest extends ApiTestAbstract
     public function testExecuteBatch() {
         $batchId = 'test_batch_id';
 
+        $params = new ExecuteBatchParameters();
+        $params
+          ->addLocaleWorkflowPair('fr-FR', 'test_wf_uid_1')
+          ->addLocaleWorkflowPair('de-DE', 'test_wf_uid_2');
+
         $endpointUrl = \vsprintf('%s/%s/batches/%s', [
             BatchApi::ENDPOINT_URL,
             $this->projectId,
@@ -202,7 +208,7 @@ class BatchApiTest extends ApiTestAbstract
             ])
             ->willReturn($this->responseMock);
 
-        $this->object->executeBatch($batchId);
+        $this->object->executeBatch($batchId, $params);
     }
 
     /**

--- a/tests/unit/BatchApiTest.php
+++ b/tests/unit/BatchApiTest.php
@@ -204,6 +204,16 @@ class BatchApiTest extends ApiTestAbstract
                 'exceptions' => FALSE,
                 'json' => [
                   'action' => BatchApi::ACTION_EXECUTE,
+                  'localeWorkflows' => [
+                    [
+                      'targetLocaleId' => 'fr-FR',
+                      'workflowUid' => 'test_wf_uid_1',
+                    ],
+                    [
+                      'targetLocaleId' => 'de-DE',
+                      'workflowUid' => 'test_wf_uid_2',
+                    ],
+                  ],
                 ],
             ])
             ->willReturn($this->responseMock);


### PR DESCRIPTION
Added `localeWorkflows` parameter to `startJobBatchV1` call as per: [Smartling API Specification - Execute batch](https://api-reference.smartling.com/#operation/startJobBatchV1)