### PR TITLE
update for guzzle 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run tests
 ---------
 `composer install`
 
-`project_id=project_id user_id=user_id user_key=user_key ./vendor/bin/phpunit`
+`account_uid=account_uid project_id=project_id user_id=user_id user_key=user_key ./vendor/bin/phpunit`
 
 Copyright and license
 ---------------------

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "authors": [],
   "require": {
     "psr/log": "~1.0",
-    "php": ">=7.2",
+    "php": ">=7.4",
     "ext-json": "*",
     "guzzlehttp/guzzle": "~7"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "smartling/api-sdk-php",
-  "version": "3.9.1",
+  "version": "4.0.0",
   "type": "library",
   "description": "PHP library to communicate with SmartlingAPI",
   "keywords": [
@@ -14,12 +14,12 @@
   "authors": [],
   "require": {
     "psr/log": "~1.0",
-    "php": ">=5.5",
+    "php": ">=7.2",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "~6"
+    "guzzlehttp/guzzle": "~7"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4"
+    "phpunit/phpunit": "~8"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,50 +4,59 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41c42afb4fdd16df3aa439b87b6451b5",
+    "content-hash": "de02918955483d35cce295116712b9f2",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "e8ed4dbf49b260ff129ff0e0400718c3269971bf"
+                "reference": "82ca75f0b1f130f018febdda29af13086da5dbac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/e8ed4dbf49b260ff129ff0e0400718c3269971bf",
-                "reference": "e8ed4dbf49b260ff129ff0e0400718c3269971bf",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/82ca75f0b1f130f018febdda29af13086da5dbac",
+                "reference": "82ca75f0b1f130f018febdda29af13086da5dbac",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.17.0"
+                "guzzlehttp/promises": "^1.5",
+                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.1"
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5-dev"
+                    "dev-master": "7.4-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -55,25 +64,56 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
                 "curl",
                 "framework",
                 "http",
                 "http client",
+                "psr-18",
+                "psr-7",
                 "rest",
                 "web service"
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5"
+                "source": "https://github.com/guzzle/guzzle/tree/master"
             },
             "funding": [
                 {
@@ -85,19 +125,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/alexeyshockov",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/gmponos",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/sagikazarmark",
-                    "type": "github"
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2020-07-02T06:52:04+00:00"
+            "time": "2022-03-20T14:21:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -105,12 +137,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c1dd809c8f51a477701052f4b9e5b4bb5c1061aa"
+                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c1dd809c8f51a477701052f4b9e5b4bb5c1061aa",
-                "reference": "c1dd809c8f51a477701052f4b9e5b4bb5c1061aa",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
+                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
                 "shasum": ""
             },
             "require": {
@@ -123,16 +155,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -166,7 +198,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/master"
+                "source": "https://github.com/guzzle/promises/tree/1.5.1"
             },
             "funding": [
                 {
@@ -182,50 +214,51 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-05T15:38:28+00:00"
+            "time": "2021-10-22T20:56:57+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9d006741ba865a45adccfac45d8e1053086a5a3f"
+                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9d006741ba865a45adccfac45d8e1053086a5a3f",
-                "reference": "9d006741ba865a45adccfac45d8e1053086a5a3f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c94a94f120803a18554c1805ef2e539f8285f9a2",
+                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
+                "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "http-interop/http-factory-tests": "^0.9",
+                "phpunit/phpunit": "^8.5.8 || ^9.3.10"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -261,6 +294,11 @@
                     "name": "Tobias Schultze",
                     "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
             "description": "PSR-7 message implementation that also provides common utility methods",
@@ -276,9 +314,132 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.x"
+                "source": "https://github.com/guzzle/psr7/tree/2.2.1"
             },
-            "time": "2021-09-05T19:11:18+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-20T21:55:58+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "22b2ef5687f43679481615605d7a15c557ce85b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/22b2ef5687f43679481615605d7a15c557ce85b1",
+                "reference": "22b2ef5687f43679481615605d7a15c557ce85b1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-09-19T09:12:31+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "36fa03d50ff82abcae81860bdaf4ed9a1510c7cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/36fa03d50ff82abcae81860bdaf4ed9a1510c7cd",
+                "reference": "36fa03d50ff82abcae81860bdaf4ed9a1510c7cd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/master"
+            },
+            "time": "2020-09-17T16:52:55+00:00"
         },
         {
             "name": "psr/http-message",
@@ -429,133 +590,35 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-idn",
-            "version": "dev-main",
+            "name": "symfony/deprecation-contracts",
+            "version": "2.5.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "749045c69efb97c70d25d7463abba812e91f3a44"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/749045c69efb97c70d25d7463abba812e91f3a44",
-                "reference": "749045c69efb97c70d25d7463abba812e91f3a44",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "symfony/polyfill-intl-normalizer": "^1.10",
-                "symfony/polyfill-php72": "^1.10"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "default-branch": true,
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Laurent Bassin",
-                    "email": "laurent@bassin.info"
-                },
-                {
-                    "name": "Trevor Rowbotham",
-                    "email": "trevor.rowbotham@pm.me"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "idn",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/main"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-09-14T14:02:44+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
             },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
+                    "function.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -572,18 +635,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/main"
             },
             "funding": [
                 {
@@ -599,84 +654,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php72",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
-                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "default-branch": true,
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-27T09:17:38+00:00"
+            "time": "2021-07-12T14:48:14+00:00"
         }
     ],
     "packages-dev": [
@@ -686,25 +664,26 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "6410c4b8352cb64218641457cef64997e6b784fb"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/6410c4b8352cb64218641457cef64997e6b784fb",
-                "reference": "6410c4b8352cb64218641457cef64997e6b784fb",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -747,32 +726,91 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T19:05:51+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.5",
+            "name": "myclabs/deep-copy",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-03T13:19:32+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "36d8a21e851a9512db2b086dc5ac2c61308f0138"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/36d8a21e851a9512db2b086dc5ac2c61308f0138",
+                "reference": "36d8a21e851a9512db2b086dc5ac2c61308f0138",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -780,10 +818,183 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
-                        "src/"
-                    ]
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-21T19:55:33+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "a0eeab580cbdf4414fef6978732510a36ed0a9d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/a0eeab580cbdf4414fef6978732510a36ed0a9d6",
+                "reference": "a0eeab580cbdf4414fef6978732510a36ed0a9d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
+            },
+            "time": "2021-06-25T13:47:51+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "21481a5c97e8332f7279e31219c32faa2da21c79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/21481a5c97e8332f7279e31219c32faa2da21c79",
+                "reference": "21481a5c97e8332f7279e31219c32faa2da21c79",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5",
+                "psalm/phar": "^4.8"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -793,46 +1004,106 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/2.x"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
             },
-            "time": "2016-01-25T08:17:30+00:00"
+            "time": "2021-12-27T22:36:43+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.5.0",
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-1.x": "1.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.x"
+            },
+            "time": "2022-03-15T21:29:03+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.2",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^6.0 || ^7.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -862,45 +1133,46 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/master"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2015-08-13T10:07:40+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "7.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/819f92bba8b001d4363065928088de22f25a3a48",
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -915,7 +1187,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -927,33 +1199,41 @@
                 "xunit"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/2.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0"
             },
-            "time": "2015-10-06T15:47:00+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-26T12:20:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.x-dev",
+            "version": "2.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -968,7 +1248,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -979,11 +1259,16 @@
                 "iterator"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0"
             },
-            "time": "2017-11-27T13:52:08+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:42:26+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1032,25 +1317,30 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "2.1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1063,7 +1353,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1073,37 +1363,43 @@
                 "timer"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1"
             },
-            "time": "2016-05-12T18:03:57+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "76fc0567751d177847112bd3e26e4890529c98da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/76fc0567751d177847112bd3e26e4890529c98da",
+                "reference": "76fc0567751d177847112bd3e26e4890529c98da",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^9.0"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1128,48 +1424,65 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/1.4"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "abandoned": true,
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2020-08-06T06:03:05+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "8.5.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "d87d433b56722da2ce236c0e47e984b4cc49a7d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d87d433b56722da2ce236c0e47e984b4cc49a7d2",
+                "reference": "d87d433b56722da2ce236c0e47e984b4cc49a7d2",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.0",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.2",
+                "phpspec/prophecy": "^1.10.3",
+                "phpunit/php-code-coverage": "^7.0.12",
+                "phpunit/php-file-iterator": "^2.0.4",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.2",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -1177,7 +1490,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -1205,40 +1518,44 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/4.8.36"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5"
             },
-            "time": "2017-06-21T08:07:12+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-03-21T06:04:39+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.x-dev",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -1253,50 +1570,49 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
-                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/2.3"
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0"
             },
-            "abandoned": true,
-            "time": "2015-10-02T06:51:40+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.x-dev",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "18a5d97c25f408f48acaf6d1b9f4079314c5996a"
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/18a5d97c25f408f48acaf6d1b9f4079314c5996a",
-                "reference": "18a5d97c25f408f48acaf6d1b9f4079314c5996a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1309,6 +1625,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -1320,14 +1640,10 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
@@ -1335,34 +1651,41 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/1.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0"
             },
-            "time": "2017-03-07T10:34:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:04:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1376,49 +1699,61 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/master"
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0"
             },
-            "time": "2015-12-08T07:14:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "4.2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "a8cb2aa3eca438e75a4b7895f04bc8f5f990bc49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a8cb2aa3eca438e75a4b7895f04bc8f5f990bc49",
+                "reference": "a8cb2aa3eca438e75a4b7895f04bc8f5f990bc49",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1445,36 +1780,42 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/1.3.7"
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2"
             },
-            "time": "2016-05-17T03:18:57+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-08-17T14:54:22+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "77200c5b1b7b073a04aca7f593a26dad7df1de35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/77200c5b1b7b073a04aca7f593a26dad7df1de35",
+                "reference": "77200c5b1b7b073a04aca7f593a26dad7df1de35",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": ">=7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1488,6 +1829,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1496,16 +1841,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1516,29 +1857,38 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1"
             },
-            "time": "2016-06-17T09:04:28+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-03-06T06:59:21+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.x-dev",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "cea85a84b00f2795341ebbbca4fa396347f2494e"
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/cea85a84b00f2795341ebbbca4fa396347f2494e",
-                "reference": "cea85a84b00f2795341ebbbca4fa396347f2494e",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2|~5.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1546,7 +1896,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1571,34 +1921,42 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/1.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0"
             },
-            "time": "2017-02-23T14:11:06+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-10T06:55:38+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.x-dev",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1612,12 +1970,122 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1628,25 +2096,147 @@
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0"
             },
-            "time": "2016-10-03T07:41:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "2.0.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=7.1"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "49529de1ea06aa1f7d30e9c6ce2d196575ff56ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/49529de1ea06aa1f7d30e9c6ce2d196575ff56ad",
+                "reference": "49529de1ea06aa1f7d30e9c6ce2d196575ff56ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-03-09T17:11:40+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1667,31 +2257,33 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/1.0.6"
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
             },
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "dev-main",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f24ae462b1d60c333df104f0b81ec7d0e12f6e9f"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f24ae462b1d60c333df104f0b81ec7d0e12f6e9f",
-                "reference": "f24ae462b1d60c333df104f0b81ec7d0e12f6e9f",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
             },
+            "provide": {
+                "ext-ctype": "*"
+            },
             "suggest": {
                 "ext-ctype": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1703,12 +2295,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1733,7 +2325,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/main"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1749,43 +2341,94 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-14T14:02:44+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "3.4.x-dev",
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "b419d648592b0b8911cbbe10d450fe314f4fd262"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/b419d648592b0b8911cbbe10d450fe314f4fd262",
+                "reference": "b419d648592b0b8911cbbe10d450fe314f4fd262",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1793,34 +2436,21 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/3.4"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/master"
             },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-06-19T13:45:26+00:00"
         }
     ],
     "aliases": [],
@@ -1829,7 +2459,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=7.2",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de02918955483d35cce295116712b9f2",
+    "content-hash": "0b60320eede11dcfd397a17ddb3d0366",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2459,7 +2459,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,10 +11,6 @@
         </testsuite>
     </testsuites>
     <filter>
-        <blacklist>
-            <directory>./vendor</directory>
-            <file>./src/SmartlingApiException.php</file>
-        </blacklist>
         <whitelist>
             <directory suffix=".php">./src</directory>
         </whitelist>

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -7,6 +7,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Smartling\AuthApi\AuthApiInterface;
@@ -23,7 +24,7 @@ abstract class BaseApiAbstract
 
     const CLIENT_LIB_ID_SDK = 'smartling-api-sdk-php';
 
-    const CLIENT_LIB_ID_VERSION = '3.9.1';
+    const CLIENT_LIB_ID_VERSION = '4.0.0';
 
     const CLIENT_USER_AGENT_EXTENSION = '(no extensions)';
 
@@ -411,10 +412,9 @@ abstract class BaseApiAbstract
     }
 
     /**
-     * @param Response $response
      * @throws SmartlingApiException
      */
-    private function processError(Response $response)
+    private function processError(ResponseInterface $response): void
     {
         try {
             $json = \json_decode($response->getBody(), true);

--- a/tests/functional/AuditLogApiFunctionalTest.php
+++ b/tests/functional/AuditLogApiFunctionalTest.php
@@ -7,7 +7,6 @@ use Smartling\AuditLog\AuditLogApi;
 use Smartling\AuditLog\Params\CreateRecordParameters;
 use Smartling\AuditLog\Params\SearchRecordParameters;
 use Smartling\AuthApi\AuthTokenProvider;
-use Smartling\Exceptions\SmartlingApiException;
 
 class AuditLogApiFunctionalTest extends TestCase
 {
@@ -34,211 +33,198 @@ class AuditLogApiFunctionalTest extends TestCase
 
     public function testCreateProjectLevelLogRecord()
     {
-        try {
-            $user_id = \uniqid();
-            $params = (new CreateRecordParameters())
-                ->setActionTime(\time())
-                ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
-                ->setFileUri("file_uri")
-                ->setFileUid("file_uid")
-                ->setSourceLocaleId('en')
-                ->setTargetLocaleIds(['de'])
-                ->setTranslationJobUid("smartling_job_uid")
-                ->setTranslationJobName("smartling_job_name")
-                ->setTranslationJobDueDate("smartling_job_due_date")
-                ->setTranslationJobAuthorize(true)
-                ->setBatchUid("batch_uid")
-                ->setDescription("description")
-                ->setClientUserId($user_id)
-                ->setClientUserEmail("user_email")
-                ->setClientUserName("user_name")
-                ->setEnvId("env_id")
-                ->setClientData("foo", "bar");
+        $user_id = $this->getRandomString();
+        $params = (new CreateRecordParameters())
+            ->setActionTime(\time())
+            ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
+            ->setFileUri("file_uri")
+            ->setFileUid("file_uid")
+            ->setSourceLocaleId('en')
+            ->setTargetLocaleIds(['de'])
+            ->setTranslationJobUid($this->getRandomString(12))
+            ->setTranslationJobName("smartling_job_name")
+            ->setTranslationJobDueDate("smartling_job_due_date")
+            ->setTranslationJobAuthorize(true)
+            ->setBatchUid("batch_uid")
+            ->setDescription("description")
+            ->setClientUserId($user_id)
+            ->setClientUserEmail("user_email")
+            ->setClientUserName("user_name")
+            ->setEnvId("env_id")
+            ->setClientData("foo", "bar");
 
-            $result = $this->auditLogApi->createProjectLevelLogRecord($params);
+        $result = $this->auditLogApi->createProjectLevelLogRecord($params);
 
-            $this->assertArrayHasKey('_index', $result);
-            $this->assertArrayHasKey('_type', $result);
-            $this->assertArrayHasKey('_id', $result);
-            $this->assertArrayHasKey('_seq_no', $result);
-        } catch (SmartlingApiException $e) {
-            $result = false;
-        }
+        $this->assertArrayHasKey('_index', $result);
+        $this->assertArrayHasKey('_type', $result);
+        $this->assertArrayHasKey('_id', $result);
+        $this->assertArrayHasKey('_seq_no', $result);
 
         return $result;
     }
 
     public function testCreateAccountLevelLogRecord()
     {
-        try {
-            $user_id = \uniqid();
-            $params = (new CreateRecordParameters())
-                ->setActionTime(\time())
-                ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
-                ->setFileUri("file_uri")
-                ->setFileUid("file_uid")
-                ->setSourceLocaleId('en')
-                ->setTargetLocaleIds(['de'])
-                ->setTranslationJobUid("smartling_job_uid")
-                ->setTranslationJobName("smartling_job_name")
-                ->setTranslationJobDueDate("smartling_job_due_date")
-                ->setTranslationJobAuthorize(true)
-                ->setBatchUid("batch_uid")
-                ->setDescription("description")
-                ->setClientUserId($user_id)
-                ->setClientUserEmail("user_email")
-                ->setClientUserName("user_name")
-                ->setEnvId("env_id")
-                ->setClientData("foo", "bar");
+        $user_id = $this->getRandomString();
+        $params = (new CreateRecordParameters())
+            ->setActionTime(\time())
+            ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
+            ->setFileUri("file_uri")
+            ->setFileUid("file_uid")
+            ->setSourceLocaleId('en')
+            ->setTargetLocaleIds(['de'])
+            ->setTranslationJobUid($this->getRandomString(12))
+            ->setTranslationJobName("smartling_job_name")
+            ->setTranslationJobDueDate("smartling_job_due_date")
+            ->setTranslationJobAuthorize(true)
+            ->setBatchUid("batch_uid")
+            ->setDescription("description")
+            ->setClientUserId($user_id)
+            ->setClientUserEmail("user_email")
+            ->setClientUserName("user_name")
+            ->setEnvId("env_id")
+            ->setClientData("foo", "bar");
 
-            $result = $this->auditLogApi->createAccountLevelLogRecord(\getenv("account_uid"), $params);
+        $result = $this->auditLogApi->createAccountLevelLogRecord(\getenv("account_uid"), $params);
 
-            $this->assertArrayHasKey('_index', $result);
-            $this->assertArrayHasKey('_type', $result);
-            $this->assertArrayHasKey('_id', $result);
-            $this->assertArrayHasKey('_seq_no', $result);
-        } catch (SmartlingApiException $e) {
-            $result = false;
-        }
-
-        return $result;
+        $this->assertArrayHasKey('_index', $result);
+        $this->assertArrayHasKey('_type', $result);
+        $this->assertArrayHasKey('_id', $result);
+        $this->assertArrayHasKey('_seq_no', $result);
     }
 
     public function testSearchProjectLevelLogRecord()
     {
-        try {
-            $user_id = \uniqid();
-            $time = \time();
+        $user_id = $this->getRandomString();
+        $time = \time();
 
-            $createParams = (new CreateRecordParameters())
-                ->setActionTime($time)
-                ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
-                ->setFileUri("file_uri")
-                ->setFileUid("file_uid")
-                ->setSourceLocaleId('en')
-                ->setTargetLocaleIds(['de'])
-                ->setTranslationJobUid("smartling_job_uid")
-                ->setTranslationJobName("smartling_job_name")
-                ->setTranslationJobDueDate("smartling_job_due_date")
-                ->setTranslationJobAuthorize(true)
-                ->setBatchUid("batch_uid")
-                ->setDescription("description")
-                ->setClientUserId($user_id)
-                ->setClientUserEmail("user_email")
-                ->setClientUserName("user_name")
-                ->setEnvId("env_id")
-                ->setClientData("foo", "bar")
-                ->setClientData("foo1", "bar1");
+        $createParams = (new CreateRecordParameters())
+            ->setActionTime($time)
+            ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
+            ->setFileUri("file_uri")
+            ->setFileUid("file_uid")
+            ->setSourceLocaleId('en')
+            ->setTargetLocaleIds(['de'])
+            ->setTranslationJobUid($this->getRandomString(12))
+            ->setTranslationJobName("smartling_job_name")
+            ->setTranslationJobDueDate("smartling_job_due_date")
+            ->setTranslationJobAuthorize(true)
+            ->setBatchUid("batch_uid")
+            ->setDescription("description")
+            ->setClientUserId($user_id)
+            ->setClientUserEmail("user_email")
+            ->setClientUserName("user_name")
+            ->setEnvId("env_id")
+            ->setClientData("foo", "bar")
+            ->setClientData("foo1", "bar1");
 
-            $createParamsArray = $createParams->exportToArray();
+        $createParamsArray = $createParams->exportToArray();
 
-            $this->auditLogApi->createProjectLevelLogRecord($createParams);
+        $this->auditLogApi->createProjectLevelLogRecord($createParams);
 
-            \sleep(1);
+        \sleep(1);
 
-            $params = (new SearchRecordParameters())
-                ->setSearchQuery("clientUserId:$user_id");
+        $params = (new SearchRecordParameters())
+            ->setSearchQuery("clientUserId:$user_id");
 
-            $result = $this->auditLogApi->searchProjectLevelLogRecord($params);
+        $result = $this->auditLogApi->searchProjectLevelLogRecord($params);
 
-            $this->assertArrayHasKey('totalCount', $result);
-            $this->assertArrayHasKey('items', $result);
+        $this->assertArrayHasKey('totalCount', $result);
+        $this->assertArrayHasKey('items', $result);
 
-            $this->assertEquals($result['totalCount'], 1);
-            $this->assertEquals(\count($result['items']), 1);
+        $this->assertEquals($result['totalCount'], 1);
+        $this->assertEquals(\count($result['items']), 1);
 
-            $this->assertEquals($result['items'][0]['actionTime'], $createParamsArray['actionTime']);
-            $this->assertEquals($result['items'][0]['actionType'], $createParamsArray['actionType']);
-            $this->assertEquals($result['items'][0]['fileUri'], $createParamsArray['fileUri']);
-            $this->assertEquals($result['items'][0]['fileUid'], $createParamsArray['fileUid']);
-            $this->assertEquals($result['items'][0]['sourceLocaleId'], $createParamsArray['sourceLocaleId']);
-            $this->assertEquals($result['items'][0]['targetLocaleIds'], $createParamsArray['targetLocaleIds']);
-            $this->assertEquals($result['items'][0]['translationJobUid'], $createParamsArray['translationJobUid']);
-            $this->assertEquals($result['items'][0]['translationJobName'], $createParamsArray['translationJobName']);
-            $this->assertEquals($result['items'][0]['translationJobDueDate'], $createParamsArray['translationJobDueDate']);
-            $this->assertEquals($result['items'][0]['translationJobAuthorize'], $createParamsArray['translationJobAuthorize']);
-            $this->assertEquals($result['items'][0]['batchUid'], $createParamsArray['batchUid']);
-            $this->assertEquals($result['items'][0]['description'], $createParamsArray['description']);
-            $this->assertEquals($result['items'][0]['clientUserId'], $createParamsArray['clientUserId']);
-            $this->assertEquals($result['items'][0]['clientUserEmail'], $createParamsArray['clientUserEmail']);
-            $this->assertEquals($result['items'][0]['clientUserName'], $createParamsArray['clientUserName']);
-            $this->assertEquals($result['items'][0]['envId'], $createParamsArray['envId']);
-            $this->assertEquals($result['items'][0]['clientData'], $createParamsArray['clientData']);
-            $this->assertEquals($result['items'][0]['accountUid'], \getenv("account_uid"));
-            $this->assertEquals($result['items'][0]['projectUid'], \getenv('project_id'));
-        } catch (SmartlingApiException $e) {
-            $result = false;
-        }
-
-        return $result;
+        $this->assertEquals($result['items'][0]['actionTime'], $createParamsArray['actionTime']);
+        $this->assertEquals($result['items'][0]['actionType'], $createParamsArray['actionType']);
+        $this->assertEquals($result['items'][0]['fileUri'], $createParamsArray['fileUri']);
+        $this->assertEquals($result['items'][0]['fileUid'], $createParamsArray['fileUid']);
+        $this->assertEquals($result['items'][0]['sourceLocaleId'], $createParamsArray['sourceLocaleId']);
+        $this->assertEquals($result['items'][0]['targetLocaleIds'], $createParamsArray['targetLocaleIds']);
+        $this->assertEquals($result['items'][0]['translationJobUid'], $createParamsArray['translationJobUid']);
+        $this->assertEquals($result['items'][0]['translationJobName'], $createParamsArray['translationJobName']);
+        $this->assertEquals($result['items'][0]['translationJobDueDate'], $createParamsArray['translationJobDueDate']);
+        $this->assertEquals($result['items'][0]['translationJobAuthorize'], $createParamsArray['translationJobAuthorize']);
+        $this->assertEquals($result['items'][0]['batchUid'], $createParamsArray['batchUid']);
+        $this->assertEquals($result['items'][0]['description'], $createParamsArray['description']);
+        $this->assertEquals($result['items'][0]['clientUserId'], $createParamsArray['clientUserId']);
+        $this->assertEquals($result['items'][0]['clientUserEmail'], $createParamsArray['clientUserEmail']);
+        $this->assertEquals($result['items'][0]['clientUserName'], $createParamsArray['clientUserName']);
+        $this->assertEquals($result['items'][0]['envId'], $createParamsArray['envId']);
+        $this->assertEquals($result['items'][0]['clientData'], $createParamsArray['clientData']);
+        $this->assertEquals($result['items'][0]['accountUid'], \getenv("account_uid"));
+        $this->assertEquals($result['items'][0]['projectUid'], \getenv('project_id'));
     }
 
     public function testSearchAccountLevelLogRecord()
     {
-        try {
-            $user_id = \uniqid();
-            $time = \time();
+        $user_id = $this->getRandomString();
+        $time = \time();
 
-            $createParams = (new CreateRecordParameters())
-                ->setActionTime($time)
-                ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
-                ->setFileUri("file_uri")
-                ->setFileUid("file_uid")
-                ->setSourceLocaleId('en')
-                ->setTargetLocaleIds(['de'])
-                ->setTranslationJobUid("smartling_job_uid")
-                ->setTranslationJobName("smartling_job_name")
-                ->setTranslationJobDueDate("smartling_job_due_date")
-                ->setTranslationJobAuthorize(true)
-                ->setBatchUid("batch_uid")
-                ->setDescription("description")
-                ->setClientUserId($user_id)
-                ->setClientUserEmail("user_email")
-                ->setClientUserName("user_name")
-                ->setEnvId("env_id")
-                ->setClientData("foo", "bar")
-                ->setClientData("foo1", "bar1");
+        $createParams = (new CreateRecordParameters())
+            ->setActionTime($time)
+            ->setActionType(CreateRecordParameters::ACTION_TYPE_UPLOAD)
+            ->setFileUri("file_uri")
+            ->setFileUid("file_uid")
+            ->setSourceLocaleId('en')
+            ->setTargetLocaleIds(['de'])
+            ->setTranslationJobUid($this->getRandomString(12))
+            ->setTranslationJobName("smartling_job_name")
+            ->setTranslationJobDueDate("smartling_job_due_date")
+            ->setTranslationJobAuthorize(true)
+            ->setBatchUid("batch_uid")
+            ->setDescription("description")
+            ->setClientUserId($user_id)
+            ->setClientUserEmail("user_email")
+            ->setClientUserName("user_name")
+            ->setEnvId("env_id")
+            ->setClientData("foo", "bar")
+            ->setClientData("foo1", "bar1");
 
-            $createParamsArray = $createParams->exportToArray();
+        $createParamsArray = $createParams->exportToArray();
 
-            $this->auditLogApi->createAccountLevelLogRecord(\getenv("account_uid"), $createParams);
+        $this->auditLogApi->createAccountLevelLogRecord(\getenv("account_uid"), $createParams);
 
-            \sleep(1);
+        \sleep(1);
 
-            $params = (new SearchRecordParameters())
-                ->setSearchQuery("clientUserId:$user_id");
+        $params = (new SearchRecordParameters())
+            ->setSearchQuery("clientUserId:$user_id");
 
-            $result = $this->auditLogApi->searchAccountLevelLogRecord(\getenv("account_uid"), $params);
+        $result = $this->auditLogApi->searchAccountLevelLogRecord(\getenv("account_uid"), $params);
 
-            $this->assertArrayHasKey('totalCount', $result);
-            $this->assertArrayHasKey('items', $result);
+        $this->assertArrayHasKey('totalCount', $result);
+        $this->assertArrayHasKey('items', $result);
 
-            $this->assertEquals($result['totalCount'], 1);
-            $this->assertEquals(\count($result['items']), 1);
+        $this->assertEquals($result['totalCount'], 1);
+        $this->assertEquals(\count($result['items']), 1);
 
-            $this->assertEquals($result['items'][0]['actionTime'], $createParamsArray['actionTime']);
-            $this->assertEquals($result['items'][0]['actionType'], $createParamsArray['actionType']);
-            $this->assertEquals($result['items'][0]['fileUri'], $createParamsArray['fileUri']);
-            $this->assertEquals($result['items'][0]['fileUid'], $createParamsArray['fileUid']);
-            $this->assertEquals($result['items'][0]['sourceLocaleId'], $createParamsArray['sourceLocaleId']);
-            $this->assertEquals($result['items'][0]['targetLocaleIds'], $createParamsArray['targetLocaleIds']);
-            $this->assertEquals($result['items'][0]['translationJobUid'], $createParamsArray['translationJobUid']);
-            $this->assertEquals($result['items'][0]['translationJobName'], $createParamsArray['translationJobName']);
-            $this->assertEquals($result['items'][0]['translationJobDueDate'], $createParamsArray['translationJobDueDate']);
-            $this->assertEquals($result['items'][0]['translationJobAuthorize'], $createParamsArray['translationJobAuthorize']);
-            $this->assertEquals($result['items'][0]['batchUid'], $createParamsArray['batchUid']);
-            $this->assertEquals($result['items'][0]['description'], $createParamsArray['description']);
-            $this->assertEquals($result['items'][0]['clientUserId'], $createParamsArray['clientUserId']);
-            $this->assertEquals($result['items'][0]['clientUserEmail'], $createParamsArray['clientUserEmail']);
-            $this->assertEquals($result['items'][0]['clientUserName'], $createParamsArray['clientUserName']);
-            $this->assertEquals($result['items'][0]['envId'], $createParamsArray['envId']);
-            $this->assertEquals($result['items'][0]['clientData'], $createParamsArray['clientData']);
-            $this->assertEquals($result['items'][0]['accountUid'], \getenv("account_uid"));
-            $this->assertEquals($result['items'][0]['projectUid'], 'none');
-        } catch (SmartlingApiException $e) {
-            $result = false;
+        $this->assertEquals($result['items'][0]['actionTime'], $createParamsArray['actionTime']);
+        $this->assertEquals($result['items'][0]['actionType'], $createParamsArray['actionType']);
+        $this->assertEquals($result['items'][0]['fileUri'], $createParamsArray['fileUri']);
+        $this->assertEquals($result['items'][0]['fileUid'], $createParamsArray['fileUid']);
+        $this->assertEquals($result['items'][0]['sourceLocaleId'], $createParamsArray['sourceLocaleId']);
+        $this->assertEquals($result['items'][0]['targetLocaleIds'], $createParamsArray['targetLocaleIds']);
+        $this->assertEquals($result['items'][0]['translationJobUid'], $createParamsArray['translationJobUid']);
+        $this->assertEquals($result['items'][0]['translationJobName'], $createParamsArray['translationJobName']);
+        $this->assertEquals($result['items'][0]['translationJobDueDate'], $createParamsArray['translationJobDueDate']);
+        $this->assertEquals($result['items'][0]['translationJobAuthorize'], $createParamsArray['translationJobAuthorize']);
+        $this->assertEquals($result['items'][0]['batchUid'], $createParamsArray['batchUid']);
+        $this->assertEquals($result['items'][0]['description'], $createParamsArray['description']);
+        $this->assertEquals($result['items'][0]['clientUserId'], $createParamsArray['clientUserId']);
+        $this->assertEquals($result['items'][0]['clientUserEmail'], $createParamsArray['clientUserEmail']);
+        $this->assertEquals($result['items'][0]['clientUserName'], $createParamsArray['clientUserName']);
+        $this->assertEquals($result['items'][0]['envId'], $createParamsArray['envId']);
+        $this->assertEquals($result['items'][0]['clientData'], $createParamsArray['clientData']);
+        $this->assertEquals($result['items'][0]['accountUid'], \getenv("account_uid"));
+        $this->assertEquals($result['items'][0]['projectUid'], 'none');
+    }
+
+    private function getRandomString(int $length = 13): string
+    {
+        if ($length > 23) {
+            throw new \InvalidArgumentException('Maximum returned length is 23');
         }
-
-        return $result;
+        $moreEntropy = $length > 13;
+        return substr(\uniqid('job', $moreEntropy), 0, $length);
     }
 }

--- a/tests/functional/AuditLogApiFunctionalTest.php
+++ b/tests/functional/AuditLogApiFunctionalTest.php
@@ -2,19 +2,19 @@
 
 namespace Smartling\Tests\Functional;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Smartling\AuditLog\AuditLogApi;
 use Smartling\AuditLog\Params\CreateRecordParameters;
 use Smartling\AuditLog\Params\SearchRecordParameters;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Exceptions\SmartlingApiException;
 
-class AuditLogApiFunctionalTest extends PHPUnit_Framework_TestCase
+class AuditLogApiFunctionalTest extends TestCase
 {
 
     private $auditLogApi;
 
-    public function setUp()
+    public function setUp(): void
     {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');

--- a/tests/functional/ContextApiFunctionalTest.php
+++ b/tests/functional/ContextApiFunctionalTest.php
@@ -2,18 +2,17 @@
 
 namespace Smartling\Tests\Functional;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Context\Params\MatchContextParameters;
 use Smartling\Context\Params\UploadContextParameters;
-use Smartling\Context\Params\UploadResourceParameters;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\Context\ContextApi;
 
 /**
  * Test class for Project API examples.
  */
-class ContextApiFunctionalTest extends PHPUnit_Framework_TestCase
+class ContextApiFunctionalTest extends TestCase
 {
 
     /**
@@ -24,7 +23,7 @@ class ContextApiFunctionalTest extends PHPUnit_Framework_TestCase
     /**
      * Test mixture.
      */
-    public function setUp() {
+    public function setUp(): void {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');
         $userSecretKey = \getenv('user_key');

--- a/tests/functional/DistributedLockServiceApiFunctionalTest.php
+++ b/tests/functional/DistributedLockServiceApiFunctionalTest.php
@@ -2,16 +2,16 @@
 
 namespace Smartling\Tests\Functional;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\DistributedLockService\DistributedLockServiceApi;
 use Smartling\Exceptions\SmartlingApiException;
 
-class DistributedLockServiceApiFunctionalTest extends PHPUnit_Framework_TestCase
+class DistributedLockServiceApiFunctionalTest extends TestCase
 {
     private $api;
 
-    public function setUp() {
+    public function setUp(): void {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');
         $userSecretKey = \getenv('user_key');

--- a/tests/functional/FileApiFunctionalTest.php
+++ b/tests/functional/FileApiFunctionalTest.php
@@ -25,12 +25,12 @@ class FileApiFunctionalTest extends TestCase
     /**
      * @var string
      */
-    const FILE_NAME = '/test.xml';
+    const FILE_NAME = 'test.xml';
 
     /**
      * @var string
      */
-    const NEW_FILE_NAME = '/new_test.xml';
+    const NEW_FILE_NAME = 'new_test.xml';
 
     /**
      * @var string

--- a/tests/functional/FileApiFunctionalTest.php
+++ b/tests/functional/FileApiFunctionalTest.php
@@ -25,12 +25,12 @@ class FileApiFunctionalTest extends TestCase
     /**
      * @var string
      */
-    const FILE_NAME = 'test.xml';
+    const FILE_NAME = '/test.xml';
 
     /**
      * @var string
      */
-    const NEW_FILE_NAME = 'new_test.xml';
+    const NEW_FILE_NAME = '/new_test.xml';
 
     /**
      * @var string
@@ -185,8 +185,8 @@ class FileApiFunctionalTest extends TestCase
                 self::FILE_NAME
             ]);
             $params->setLocaleIds([
-                "fr",
-                "de"
+                "fr-FR",
+                "de-DE"
             ]);
             $params->setLocaleMode(DownloadMultipleFilesParameters::LOCALE_MODE_LOCALE_IN_NAME_AND_PATH);
             $params->setFileNameMode(DownloadMultipleFilesParameters::FILE_NAME_MODE_LOCALE_LAST);
@@ -295,6 +295,7 @@ class FileApiFunctionalTest extends TestCase
 
     /**
      * Test for renaming file.
+     * @depends testFileApiUploadFile
      */
     public function testFileApiRenameFile() {
         try {

--- a/tests/functional/FileApiFunctionalTest.php
+++ b/tests/functional/FileApiFunctionalTest.php
@@ -3,7 +3,7 @@
 namespace Smartling\Tests\Functional;
 
 use GuzzleHttp\Psr7\Stream;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\File\FileApi;
@@ -14,7 +14,7 @@ use Smartling\File\Params\ListFilesParameters;
 /**
  * Test class for File API examples.
  */
-class FileApiFunctionalTest extends PHPUnit_Framework_TestCase
+class FileApiFunctionalTest extends TestCase
 {
 
     /**
@@ -65,7 +65,7 @@ class FileApiFunctionalTest extends PHPUnit_Framework_TestCase
     /**
      * Reset all files in Smartling after tests.
      */
-    public static function tearDownAfterClass() {
+    public static function tearDownAfterClass(): void {
         $authProvider = AuthTokenProvider::create(\getenv('user_id'), \getenv('user_key'));
         $fileApi = FileApi::create($authProvider, \getenv('project_id'));
 
@@ -82,7 +82,7 @@ class FileApiFunctionalTest extends PHPUnit_Framework_TestCase
     /**
      * Test mixture.
      */
-    public function setUp() {
+    public function setUp(): void {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');
         $userSecretKey = \getenv('user_key');

--- a/tests/functional/JobsApiFunctionalTest.php
+++ b/tests/functional/JobsApiFunctionalTest.php
@@ -76,43 +76,32 @@ class JobsApiFunctionalTest extends TestCase
         }
     }
 
-    /**
-     * Create job.
-     *
-     * @return string
-     */
-    private function createJob()
+    private function createJob(): string
     {
-        try {
-            $params = new CreateJobParameters();
-            $params->setName('Test Job Name ' . \time());
-            $params->setDescription('Test Job Description ' . \time());
-            $params->setDueDate(DateTime::createFromFormat('Y-m-d H:i:s', '2037-12-31 23:59:59', new DateTimeZone('UTC')));
-            $params->setTargetLocales(['es', 'fr']);
-            $result = $this->jobsApi->createJob($params);
+        $params = new CreateJobParameters();
+        $params->setName('Test Job Name ' . \time());
+        $params->setDescription('Test Job Description ' . \time());
+        $params->setDueDate(DateTime::createFromFormat('Y-m-d H:i:s', '2037-12-31 23:59:59', new DateTimeZone('UTC')));
+        $params->setTargetLocales(['es-ES', 'fr-FR']);
+        $result = $this->jobsApi->createJob($params);
 
-            $this->assertArrayHasKey('translationJobUid', $result);
-            $this->assertArrayHasKey('jobName', $result);
-            $this->assertArrayHasKey('targetLocaleIds', $result);
-            $this->assertArrayHasKey('description', $result);
-            $this->assertArrayHasKey('dueDate', $result);
-            $this->assertArrayHasKey('referenceNumber', $result);
-            $this->assertArrayHasKey('callbackUrl', $result);
-            $this->assertArrayHasKey('callbackMethod', $result);
-            $this->assertArrayHasKey('createdDate', $result);
-            $this->assertArrayHasKey('modifiedDate', $result);
-            $this->assertArrayHasKey('createdByUserUid', $result);
-            $this->assertArrayHasKey('modifiedByUserUid', $result);
-            $this->assertArrayHasKey('firstCompletedDate', $result);
-            $this->assertArrayHasKey('lastCompletedDate', $result);
-            $this->assertArrayHasKey('jobStatus', $result);
+        $this->assertArrayHasKey('translationJobUid', $result);
+        $this->assertArrayHasKey('jobName', $result);
+        $this->assertArrayHasKey('targetLocaleIds', $result);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertArrayHasKey('dueDate', $result);
+        $this->assertArrayHasKey('referenceNumber', $result);
+        $this->assertArrayHasKey('callbackUrl', $result);
+        $this->assertArrayHasKey('callbackMethod', $result);
+        $this->assertArrayHasKey('createdDate', $result);
+        $this->assertArrayHasKey('modifiedDate', $result);
+        $this->assertArrayHasKey('createdByUserUid', $result);
+        $this->assertArrayHasKey('modifiedByUserUid', $result);
+        $this->assertArrayHasKey('firstCompletedDate', $result);
+        $this->assertArrayHasKey('lastCompletedDate', $result);
+        $this->assertArrayHasKey('jobStatus', $result);
 
-            $result = $result['translationJobUid'];
-        } catch (SmartlingApiException $e) {
-            $result = false;
-        }
-
-        return $result;
+        return $result['translationJobUid'];
     }
 
     /**

--- a/tests/functional/JobsApiFunctionalTest.php
+++ b/tests/functional/JobsApiFunctionalTest.php
@@ -4,7 +4,7 @@ namespace Smartling\Tests\Functional;
 
 use DateTime;
 use DateTimeZone;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\File\FileApi;
@@ -21,7 +21,7 @@ use Smartling\Jobs\Params\UpdateJobParameters;
 /**
  * Test class for Jobs API examples.
  */
-class JobsApiFunctionalTest extends PHPUnit_Framework_TestCase
+class JobsApiFunctionalTest extends TestCase
 {
 
     /**
@@ -42,7 +42,7 @@ class JobsApiFunctionalTest extends PHPUnit_Framework_TestCase
     /**
      * Test mixture.
      */
-    public function setUp()
+    public function setUp(): void
     {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');
@@ -67,7 +67,7 @@ class JobsApiFunctionalTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         try {
             $this->cancelJob($this->jobId);

--- a/tests/functional/ProgressTrackerApiFunctionalTest.php
+++ b/tests/functional/ProgressTrackerApiFunctionalTest.php
@@ -2,7 +2,7 @@
 
 namespace Smartling\Tests\Functional;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\ProgressTracker\Params\RecordParameters;
@@ -11,7 +11,7 @@ use Smartling\ProgressTracker\ProgressTrackerApi;
 /**
  * Test class for Progress Tracker API examples.
  */
-class ProgressTrackerApiFunctionalTest extends PHPUnit_Framework_TestCase
+class ProgressTrackerApiFunctionalTest extends TestCase
 {
 
     /**
@@ -22,7 +22,7 @@ class ProgressTrackerApiFunctionalTest extends PHPUnit_Framework_TestCase
     /**
      * Test mixture.
      */
-    public function setUp()
+    public function setUp(): void
     {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');

--- a/tests/functional/ProjectApiFunctionalTest.php
+++ b/tests/functional/ProjectApiFunctionalTest.php
@@ -2,7 +2,7 @@
 
 namespace Smartling\Tests\Functional;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\Exceptions\SmartlingApiException;
 use Smartling\Project\ProjectApi;
@@ -10,7 +10,7 @@ use Smartling\Project\ProjectApi;
 /**
  * Test class for Project API examples.
  */
-class ProjectApiFunctionalTest extends PHPUnit_Framework_TestCase
+class ProjectApiFunctionalTest extends TestCase
 {
 
     /**
@@ -21,7 +21,7 @@ class ProjectApiFunctionalTest extends PHPUnit_Framework_TestCase
     /**
      * Test mixture.
      */
-    public function setUp() {
+    public function setUp(): void {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');
         $userSecretKey = \getenv('user_key');

--- a/tests/functional/TranslationRequestsApiFunctionalTest.php
+++ b/tests/functional/TranslationRequestsApiFunctionalTest.php
@@ -55,7 +55,9 @@ class TranslationRequestsApiFunctionalTest extends TestCase
 
         $response = $this->translationRequestsApi->createTranslationRequest(self::BUCKET_NAME, $createParams);
 
-        self::assertArraySubset($createParams->exportToArray(), $response);
+        foreach (array_keys($createParams->exportToArray()) as $key) {
+            self::assertArrayHasKey($key, $response);
+        }
         self::assertArrayHasKey('translationRequestUid', $response);
     }
 
@@ -74,7 +76,9 @@ class TranslationRequestsApiFunctionalTest extends TestCase
 
         $response = $this->translationRequestsApi->createTranslationRequest(self::BUCKET_NAME, $createParams);
 
-        self::assertArraySubset($createParams->exportToArray(), $response);
+        foreach (array_keys($createParams->exportToArray()) as $key) {
+            self::assertArrayHasKey($key, $response);
+        }
         self::assertArrayHasKey('translationRequestUid', $response);
 
         $translationRequestUid = $response['translationRequestUid'];
@@ -82,10 +86,11 @@ class TranslationRequestsApiFunctionalTest extends TestCase
         $updateParams = (new UpdateTranslationRequestParams())
             ->setTitle('Submission UPDATED');
 
-
         $updateResponse = $this->translationRequestsApi->updateTranslationRequest(self::BUCKET_NAME, $translationRequestUid, $updateParams);
 
-        self::assertArraySubset($updateParams->exportToArray(), $updateResponse);
+        foreach (array_keys($updateParams->exportToArray()) as $key) {
+            self::assertArrayHasKey($key, $updateResponse);
+        }
         self::assertArrayHasKey('translationRequestUid', $updateResponse);
         self::assertEquals($translationRequestUid, $updateResponse['translationRequestUid']);
     }
@@ -105,14 +110,18 @@ class TranslationRequestsApiFunctionalTest extends TestCase
 
         $response = $this->translationRequestsApi->createTranslationRequest(self::BUCKET_NAME, $createParams);
 
-        self::assertArraySubset($createParams->exportToArray(), $response);
+        foreach (array_keys($createParams->exportToArray()) as $key) {
+            self::assertArrayHasKey($key, $response);
+        }
         self::assertArrayHasKey('translationRequestUid', $response);
 
         $translationRequestUid = $response['translationRequestUid'];
 
         $getResponsePositive = $this->translationRequestsApi->getTranslationRequest(self::BUCKET_NAME, $translationRequestUid);
 
-        self::assertArraySubset($createParams->exportToArray(), $getResponsePositive);
+        foreach (array_keys($createParams->exportToArray()) as $key) {
+            self::assertArrayHasKey($key, $getResponsePositive);
+        }
         self::assertArrayHasKey('translationRequestUid', $getResponsePositive);
     }
 
@@ -131,7 +140,9 @@ class TranslationRequestsApiFunctionalTest extends TestCase
 
         $response = $this->translationRequestsApi->createTranslationRequest(self::BUCKET_NAME, $createParams);
 
-        self::assertArraySubset($createParams->exportToArray(), $response);
+        foreach (array_keys($createParams->exportToArray()) as $key) {
+            self::assertArrayHasKey($key, $response);
+        }
         self::assertArrayHasKey('translationRequestUid', $response);
 
         $translationRequestUid = $response['translationRequestUid'];
@@ -147,7 +158,7 @@ class TranslationRequestsApiFunctionalTest extends TestCase
         self::assertTrue(0 === \count($items));
 
         $searchResponse = $this->translationRequestsApi->searchTranslationRequests(self::BUCKET_NAME,
-            (new SearchTranslationRequestParams())->setFileUri(\vsprintf('%%%s%%', [$time]))
+            (new SearchTranslationRequestParams())->setFileUri(\vsprintf('/posts/hello-world_1_%s_post.xml', [$time]))
         );
 
         self::assertTrue(\is_array($searchResponse));
@@ -157,5 +168,4 @@ class TranslationRequestsApiFunctionalTest extends TestCase
         self::assertTrue(1 === \count($items));
         self::assertTrue($translationRequestUid === $items[0]['translationRequestUid']);
     }
-
 }

--- a/tests/functional/TranslationRequestsApiFunctionalTest.php
+++ b/tests/functional/TranslationRequestsApiFunctionalTest.php
@@ -2,13 +2,14 @@
 
 namespace Smartling\Tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\TranslationRequests\Params\CreateTranslationRequestParams;
 use Smartling\TranslationRequests\Params\SearchTranslationRequestParams;
 use Smartling\TranslationRequests\Params\UpdateTranslationRequestParams;
 use Smartling\TranslationRequests\TranslationRequestsApi;
 
-class TranslationRequestsApiFunctionalTest extends \PHPUnit_Framework_TestCase
+class TranslationRequestsApiFunctionalTest extends TestCase
 {
     const BUCKET_NAME = 'tst-bucket';
 
@@ -20,7 +21,7 @@ class TranslationRequestsApiFunctionalTest extends \PHPUnit_Framework_TestCase
     /**
      * Test mixture.
      */
-    public function setUp()
+    public function setUp(): void
     {
         $projectId = \getenv('project_id');
         $userIdentifier = \getenv('user_id');

--- a/tests/unit/ApiTestAbstract.php
+++ b/tests/unit/ApiTestAbstract.php
@@ -262,7 +262,6 @@ abstract class ApiTestAbstract extends TestCase
      */
     protected function setUp(): void
     {
-        date_default_timezone_set('Europe/Kiev');
         $this->prepareHttpClientMock();
         $this->prepareAuthProviderMock();
         $this->prepareClientResponseMock();

--- a/tests/unit/ApiTestAbstract.php
+++ b/tests/unit/ApiTestAbstract.php
@@ -3,21 +3,25 @@
 namespace Smartling\Tests\Unit;
 
 use GuzzleHttp\ClientInterface;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Smartling\AuthApi\AuthApiInterface;
+use Smartling\AuthApi\AuthTokenProvider;
 use Smartling\BaseApiAbstract;
 
 /**
  * Class ApiTestAbstract
  * @package Smartling\Tests
  */
-abstract class ApiTestAbstract extends \PHPUnit_Framework_TestCase
+abstract class ApiTestAbstract extends TestCase
 {
     const JSON_OBJECT_AS_ARRAY = 1;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|BaseApiAbstract
+     * @var MockObject|BaseApiAbstract
      */
     protected $object;
 
@@ -52,12 +56,12 @@ abstract class ApiTestAbstract extends \PHPUnit_Framework_TestCase
     protected $responseAsync = '{"response":{"data":{"message":"message", "url":"url"},"code":"ACCEPTED"}}';
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|ClientInterface
+     * @var MockObject|ClientInterface
      */
     protected $client;
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|AuthApiInterface
+     * @var MockObject|AuthApiInterface
      */
     protected $authProvider;
 
@@ -67,12 +71,12 @@ abstract class ApiTestAbstract extends \PHPUnit_Framework_TestCase
     protected $streamPlaceholder = 'stream';
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|ResponseInterface
+     * @var MockObject|ResponseInterface
      */
     protected $responseMock;
 
     /**
-     * @var RequestInterface | PHPUnit_Framework_MockObject_MockObject
+     * @var RequestInterface|MockObject
      */
     protected $requestMock;
 
@@ -252,11 +256,10 @@ abstract class ApiTestAbstract extends \PHPUnit_Framework_TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prepareHttpClientMock();
         $this->prepareAuthProviderMock();
         $this->prepareClientResponseMock();
     }
-
 }

--- a/tests/unit/ApiTestAbstract.php
+++ b/tests/unit/ApiTestAbstract.php
@@ -3,6 +3,7 @@
 namespace Smartling\Tests\Unit;
 
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -265,5 +266,16 @@ abstract class ApiTestAbstract extends TestCase
         $this->prepareHttpClientMock();
         $this->prepareAuthProviderMock();
         $this->prepareClientResponseMock();
+    }
+
+    protected function getResponse(string $response, int $code = 200): ResponseInterface
+    {
+        $responseMock = $this->createMock(Response::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('__toString')->willReturn($response);
+        $responseMock->method('getBody')->willReturn($stream);
+        $responseMock->method('getStatusCode')->willReturn($code);
+
+        return $responseMock;
     }
 }

--- a/tests/unit/ApiTestAbstract.php
+++ b/tests/unit/ApiTestAbstract.php
@@ -203,7 +203,7 @@ abstract class ApiTestAbstract extends TestCase
 
     protected function prepareAuthProviderMock()
     {
-        $this->authProvider = $this->getMockBuilder('\Smartling\AuthApi\AuthApiInterface')
+        $this->authProvider = $this->getMockBuilder(AuthTokenProvider::class)
             ->setMethods(
                 [
                     'getAccessToken',
@@ -241,10 +241,13 @@ abstract class ApiTestAbstract extends TestCase
                         self::JSON_OBJECT_AS_ARRAY
                     )
                 );
+            $stream = $this->createMock(StreamInterface::class);
+            $stream->method('read')->willReturn($this->validResponse);
+            $stream->method('__toString')->willReturn($this->validResponse);
 
             $this->responseMock->expects(self::any())
                 ->method('getBody')
-                ->willReturn($this->validResponse);
+                ->willReturn($stream);
         }
 
         $this->responseMock->expects($this->any())
@@ -258,6 +261,7 @@ abstract class ApiTestAbstract extends TestCase
      */
     protected function setUp(): void
     {
+        date_default_timezone_set('Europe/Kiev');
         $this->prepareHttpClientMock();
         $this->prepareAuthProviderMock();
         $this->prepareClientResponseMock();

--- a/tests/unit/AuditLogApiTest.php
+++ b/tests/unit/AuditLogApiTest.php
@@ -41,7 +41,7 @@ class AuditLogApiTest extends ApiTestAbstract
             ->setClientData("foo", "bar")
             ->setClientData("foo1", "bar1");
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('post', $endpointUrl, [
                 'headers' => [
@@ -114,7 +114,7 @@ class AuditLogApiTest extends ApiTestAbstract
             ->setClientData("foo", "bar")
             ->setClientData("foo1", "bar1");
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('post', $endpointUrl, [
                 'headers' => [
@@ -172,7 +172,7 @@ class AuditLogApiTest extends ApiTestAbstract
             ->setLimit(100)
             ->setSort("baz", SearchRecordParameters::ORDER_ASC);
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('get', $endpointUrl, [
                 'headers' => [
@@ -215,7 +215,7 @@ class AuditLogApiTest extends ApiTestAbstract
             ->setLimit(100)
             ->setSort("baz", SearchRecordParameters::ORDER_ASC);
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('get', $endpointUrl, [
                 'headers' => [

--- a/tests/unit/AuditLogApiTest.php
+++ b/tests/unit/AuditLogApiTest.php
@@ -238,7 +238,7 @@ class AuditLogApiTest extends ApiTestAbstract
         $this->object->searchAccountLevelLogRecord($accountUid, $createParams);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareAuditLogApiMock();

--- a/tests/unit/AuthApiTest.php
+++ b/tests/unit/AuthApiTest.php
@@ -3,6 +3,7 @@
 namespace Smartling\Tests;
 
 use Smartling\AuthApi\AuthTokenProvider;
+use Smartling\Exceptions\SmartlingApiException;
 use Smartling\Tests\Unit\ApiTestAbstract;
 
 /**
@@ -69,9 +70,6 @@ class AuthApiTest extends ApiTestAbstract
      *
      * AuthTokenProvider::sendRequest() - 401 - Invalid credentials.
      * [Some]Api::sendRequest() - 401 - expired access token.
-     *
-     * @expectedException Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage AuthProvider expected to be instance of AuthApiInterface, type given:NULL
      */
     public function testAuthenticateWithInvalidCredentials() {
         $response_mock = $this->getMockBuilder('GuzzleHttp\Psr7\Response')
@@ -111,6 +109,8 @@ class AuthApiTest extends ApiTestAbstract
             ])
             ->getMock();
 
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('AuthProvider expected to be instance of AuthApiInterface, type given:NULL');
         $this->invokeMethod($auth_api_mock, 'authenticate');
     }
 

--- a/tests/unit/AuthApiTest.php
+++ b/tests/unit/AuthApiTest.php
@@ -15,7 +15,7 @@ class AuthApiTest extends ApiTestAbstract
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareAuthApiMock();

--- a/tests/unit/BaseApiAbstractTest.php
+++ b/tests/unit/BaseApiAbstractTest.php
@@ -25,12 +25,7 @@ class BaseApiAbstractTest extends ApiTestAbstract
         $instance = FileApi::create($this->authProvider, 'test');
         $http_client = $this->invokeMethod($instance, 'getHttpClient');
 
-        $this->assertNotFalse(
-            \strpos(
-                $http_client->getConfig()['headers']['User-Agent'],
-                'smartling-api-sdk-php/3.9.1 (no extensions) GuzzleHttp/6'
-            )
-        );
+        $this->assertEquals('smartling-api-sdk-php/4.0.0 (no extensions) GuzzleHttp/7', $http_client->getConfig()['headers']['User-Agent']);
     }
 
     /**
@@ -44,12 +39,7 @@ class BaseApiAbstractTest extends ApiTestAbstract
         $instance = FileApi::create($this->authProvider, 'test');
         $http_client = $this->invokeMethod($instance, 'getHttpClient');
 
-        $this->assertNotFalse(
-            \strpos(
-                $http_client->getConfig()['headers']['User-Agent'],
-                'php-connector/1.2.3 (no extensions) GuzzleHttp/6'
-            )
-        );
+        $this->assertEquals('php-connector/1.2.3 (no extensions) GuzzleHttp/7', $http_client->getConfig()['headers']['User-Agent']);
     }
 
     /**
@@ -64,11 +54,6 @@ class BaseApiAbstractTest extends ApiTestAbstract
         $instance = FileApi::create($this->authProvider, 'test');
         $http_client = $this->invokeMethod($instance, 'getHttpClient');
 
-        $this->assertNotFalse(
-            \strpos(
-                $http_client->getConfig()['headers']['User-Agent'],
-                'php-connector/1.2.3 dependency-1/version-1 dependency-2/version-2 GuzzleHttp/6'
-            )
-        );
+        $this->assertEquals('php-connector/1.2.3 dependency-1/version-1 dependency-2/version-2 GuzzleHttp/7', $http_client->getConfig()['headers']['User-Agent']);
     }
 }

--- a/tests/unit/BaseApiAbstractTest.php
+++ b/tests/unit/BaseApiAbstractTest.php
@@ -7,7 +7,7 @@ use Smartling\File\FileApi;
 
 class BaseApiAbstractTest extends ApiTestAbstract
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/BatchApiTest.php
+++ b/tests/unit/BatchApiTest.php
@@ -15,7 +15,7 @@ class BatchApiTest extends ApiTestAbstract
     /**
      * {@inheritdoc}
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
         $this->prepareBatchApiMock();
     }

--- a/tests/unit/BatchApiTest.php
+++ b/tests/unit/BatchApiTest.php
@@ -90,8 +90,6 @@ class BatchApiTest extends ApiTestAbstract
 
     /**
      * @covers \Smartling\Batch\BatchApi::uploadBatchFile
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage BatchUid cannot be empty.
      */
     public function testUploadBatchFileWithEmptyBatchUid()
     {
@@ -100,6 +98,8 @@ class BatchApiTest extends ApiTestAbstract
         $fileUri = 'dummy file uri`';
         $extension = 'xml';
         $params = new UploadFileParameters();
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('BatchUid cannot be empty');
         $this->object->uploadBatchFile($fileRealPath, $fileUri, $extension, $batchId, $params);
     }
 

--- a/tests/unit/ContextApiTest.php
+++ b/tests/unit/ContextApiTest.php
@@ -7,6 +7,7 @@ use Smartling\Context\Params\MatchContextParameters;
 use Smartling\Context\Params\MissingResourcesParameters;
 use Smartling\Context\Params\UpdateResourceStateParameters;
 use Smartling\Context\Params\UploadContextParameters;
+use Smartling\Exceptions\SmartlingApiException;
 use Smartling\Tests\Unit\ApiTestAbstract;
 use Smartling\Context\Params\UploadResourceParameters;
 
@@ -240,9 +241,6 @@ class ContextApiTest extends ApiTestAbstract
 
     /**
      * @covers \Smartling\Context\ContextApi::uploadAndMatchContext
-     *
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage When content is specified using the data:// protocol, name is a required request body field
      */
     public function testUploadAndMatchContextWithDataProtocolFailsWhenNoNameSupplied() {
         $fileUri = './tests/resources/context.html';
@@ -254,6 +252,8 @@ class ContextApiTest extends ApiTestAbstract
         $params->setContent(sprintf('data://text/html;base64,%s', base64_encode(file_get_contents($fileUri))));
         $params->setMatchParams($matchParams);
 
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('When content is specified using the data:// protocol, name is a required request body field');
         $this->object->uploadAndMatchContext($params);
     }
 

--- a/tests/unit/ContextApiTest.php
+++ b/tests/unit/ContextApiTest.php
@@ -21,7 +21,7 @@ class ContextApiTest extends ApiTestAbstract
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareContextApiMock();

--- a/tests/unit/DistributedLockServiceApiTest.php
+++ b/tests/unit/DistributedLockServiceApiTest.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Smartling\Tests\Unit;
-use GuzzleHttp\Psr7\Response;
 use Smartling\BaseApiAbstract;
 use Smartling\DistributedLockService\DistributedLockServiceApi;
 
@@ -9,10 +8,6 @@ class DistributedLockServiceApiTest extends ApiTestAbstract
 {
     public function testAcquireLock() {
         $endpointUrl = 'locks';
-
-        $responseMock = $this->createMock(Response::class);
-        $responseMock->method('getBody')
-            ->willReturn('{"response":{"data":{"key":"test","releaseTime":"2019-10-01T12:22:00Z"},"code":"SUCCESS"}}');
 
         $this->setExpectations(
             BaseApiAbstract::HTTP_METHOD_POST,
@@ -23,7 +18,7 @@ class DistributedLockServiceApiTest extends ApiTestAbstract
                 'timeout' => -1000,
                 'wait' => -1000,
             ],
-            $responseMock
+            $this->getResponse('{"response":{"data":{"key":"test","releaseTime":"2019-10-01T12:22:00Z"},"code":"SUCCESS"}}'),
         );
         $this->getApiMock()->acquireLock('test', 5);
     }
@@ -31,14 +26,11 @@ class DistributedLockServiceApiTest extends ApiTestAbstract
     public function testReleaseLock() {
         $endpointUrl = 'locks/test';
 
-        $responseMock = $this->createMock(Response::class);
-        $responseMock->method('getBody')->willReturn('{"response":{"data":null,"code":"SUCCESS"}}');
-
         $this->setExpectations(
             BaseApiAbstract::HTTP_METHOD_DELETE,
             DistributedLockServiceApi::ENDPOINT_URL . '/' . $this->projectId . '/' . $endpointUrl,
             [],
-            $responseMock
+            $this->getResponse('{"response":{"data":null,"code":"SUCCESS"}}'),
         );
         $this->getApiMock()->releaseLock('test');
     }
@@ -46,17 +38,13 @@ class DistributedLockServiceApiTest extends ApiTestAbstract
     public function testRenewLock() {
         $endpointUrl = 'locks/test';
 
-        $responseMock = $this->createMock(Response::class);
-        $responseMock->method('getBody')
-            ->willReturn('{"response":{"data":{"key":"test","releaseTime":"2019-10-01T12:22:00Z"},"code":"SUCCESS"}}');
-
         $this->setExpectations(
             BaseApiAbstract::HTTP_METHOD_PUT,
             DistributedLockServiceApi::ENDPOINT_URL . '/' . $this->projectId . '/' . $endpointUrl,
             [
                 'ttl' => 5000,
             ],
-            $responseMock
+            $this->getResponse('{"response":{"data":{"key":"test","releaseTime":"2019-10-01T12:22:00Z"},"code":"SUCCESS"}}'),
         );
         $this->getApiMock()->renewLock('test', 5);
     }

--- a/tests/unit/DistributedLockServiceApiTest.php
+++ b/tests/unit/DistributedLockServiceApiTest.php
@@ -10,7 +10,7 @@ class DistributedLockServiceApiTest extends ApiTestAbstract
     public function testAcquireLock() {
         $endpointUrl = 'locks';
 
-        $responseMock = $this->getMock(Response::class);
+        $responseMock = $this->createMock(Response::class);
         $responseMock->method('getBody')
             ->willReturn('{"response":{"data":{"key":"test","releaseTime":"2019-10-01T12:22:00Z"},"code":"SUCCESS"}}');
 
@@ -31,7 +31,7 @@ class DistributedLockServiceApiTest extends ApiTestAbstract
     public function testReleaseLock() {
         $endpointUrl = 'locks/test';
 
-        $responseMock = $this->getMock(Response::class);
+        $responseMock = $this->createMock(Response::class);
         $responseMock->method('getBody')->willReturn('{"response":{"data":null,"code":"SUCCESS"}}');
 
         $this->setExpectations(
@@ -46,7 +46,7 @@ class DistributedLockServiceApiTest extends ApiTestAbstract
     public function testRenewLock() {
         $endpointUrl = 'locks/test';
 
-        $responseMock = $this->getMock(Response::class);
+        $responseMock = $this->createMock(Response::class);
         $responseMock->method('getBody')
             ->willReturn('{"response":{"data":{"key":"test","releaseTime":"2019-10-01T12:22:00Z"},"code":"SUCCESS"}}');
 

--- a/tests/unit/ExceptionTest.php
+++ b/tests/unit/ExceptionTest.php
@@ -1,12 +1,13 @@
 <?php
 
 namespace Smartling\Tests;
+use PHPUnit\Framework\TestCase;
 use Smartling\Exceptions\SmartlingApiException;
 
 /**
  * Test class for Smartling\Exceptions\SmartlingApiException.
  */
-class ExceptionTest extends \PHPUnit_Framework_TestCase
+class ExceptionTest extends TestCase
 {
 
     /**

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -3,6 +3,7 @@
 namespace Smartling\Tests\Unit;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Smartling\Exceptions\SmartlingApiException;
 use Smartling\File\FileApi;
 use Smartling\File\Params\DownloadFileParameters;
 use Smartling\File\Params\DownloadMultipleFilesParameters;
@@ -193,13 +194,12 @@ class FileApiTest extends ApiTestAbstract
      * @dataProvider invalidFileUploadNamespaceParams
      *
      * @param mixed $invalidValue
-     *
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage Invalid namespace found, not a string or empty string
      */
     public function testFileUploadParamsNamespaceFailures($invalidValue)
     {
         $fileUploadParams = new UploadFileParameters();
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('Invalid namespace found, not a string or empty string');
         $fileUploadParams->setNamespace($invalidValue);
     }
 
@@ -411,7 +411,6 @@ class FileApiTest extends ApiTestAbstract
     /**
      * @covers       \Smartling\File\FileApi::downloadFile
      * @dataProvider downloadFileLocaleCheckSuccessParams
-     * @expectedException Smartling\Exceptions\SmartlingApiException
      *
      * @param $options
      * @param $locale
@@ -419,6 +418,7 @@ class FileApiTest extends ApiTestAbstract
     public function testDownloadFileLocaleCheckFails($options, $locale)
     {
         $this->prepareClientResponseMock();
+        $this->expectException(SmartlingApiException::class);
         $this->object->downloadFile('test.xml', $locale, $options);
     }
 
@@ -450,8 +450,6 @@ class FileApiTest extends ApiTestAbstract
 
     /**
      * @covers \Smartling\File\FileApi::lastModified
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage No data found for file test.xml.
      */
     public function testLastModifiedInvalidResponseNoDataFoundNoItems()
     {
@@ -467,13 +465,13 @@ class FileApiTest extends ApiTestAbstract
               ->method('getBody')
               ->willReturn($response);
 
+        $this->expectException(SmartlingApiException::class);
+        $this->expectErrorMessage('No data found for file test.xml.');
         $this->object->lastModified('test.xml');
     }
 
     /**
      * @covers \Smartling\File\FileApi::lastModified
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage No data found for file test.xml.
      */
     public function testLastModifiedInvalidResponseNoDataFoundItemsNotArray()
     {
@@ -489,13 +487,13 @@ class FileApiTest extends ApiTestAbstract
             ->method('getBody')
             ->willReturn($response);
 
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('No data found for file test.xml.');
         $this->object->lastModified('test.xml');
     }
 
     /**
      * @covers \Smartling\File\FileApi::lastModified
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage Can't parse formatted time string: test.
      */
     public function testLastModifiedInvalidResponseCantParseFormattedTimeString()
     {
@@ -511,13 +509,14 @@ class FileApiTest extends ApiTestAbstract
             ->method('getBody')
             ->willReturn($response);
 
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage("Can't parse formatted time string: test.");
+
         $this->object->lastModified('test.xml');
     }
 
     /**
      * @covers \Smartling\File\FileApi::lastModified
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage Property "lastModified" is not found.
      */
     public function testLastModifiedInvalidResponseLastModifiedIsNotSet()
     {
@@ -533,6 +532,8 @@ class FileApiTest extends ApiTestAbstract
             ->method('getBody')
             ->willReturn($response);
 
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('Property "lastModified" is not found.');
         $this->object->lastModified('test.xml');
     }
 
@@ -753,7 +754,6 @@ class FileApiTest extends ApiTestAbstract
 
     /**
      * @covers \Smartling\File\FileApi::sendRequest
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
      */
     public function testValidationErrorSendRequest()
     {
@@ -790,6 +790,7 @@ class FileApiTest extends ApiTestAbstract
             ->willReturn($this->responseMock);
 
         $requestData = $this->invokeMethod($this->object, 'getDefaultRequestData', ['query', []]);
+        $this->expectException(SmartlingApiException::class);
 
         $this->invokeMethod($this->object, 'setBaseUrl', [FileApi::ENDPOINT_URL . '/' . $this->projectId]);
         $this->invokeMethod($this->object, 'sendRequest', ['context/html', $requestData, 'get']);
@@ -797,8 +798,6 @@ class FileApiTest extends ApiTestAbstract
 
     /**
      * @covers \Smartling\File\FileApi::sendRequest
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage Bad response format from Smartling
      */
     public function testBadJsonFormatSendRequest()
     {
@@ -835,6 +834,8 @@ class FileApiTest extends ApiTestAbstract
             ->willReturn($this->responseMock);
 
         $requestData = $this->invokeMethod($this->object, 'getDefaultRequestData', ['query', []]);
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('Bad response format from Smartling');
 
         $this->invokeMethod($this->object, 'setBaseUrl', [FileApi::ENDPOINT_URL . '/' . $this->projectId]);
         $this->invokeMethod($this->object, 'sendRequest', ['context/html', $requestData, 'get']);
@@ -842,8 +843,6 @@ class FileApiTest extends ApiTestAbstract
 
     /**
      * @covers \Smartling\File\FileApi::sendRequest
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage Bad response format from Smartling
      */
     public function testBadJsonFormatInErrorMessageSendRequest()
     {
@@ -880,6 +879,8 @@ class FileApiTest extends ApiTestAbstract
             ->willReturn($this->responseMock);
 
         $requestData = $this->invokeMethod($this->object, 'getDefaultRequestData', ['query', []]);
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('Bad response format from Smartling');
 
         $this->invokeMethod($this->object, 'setBaseUrl', [FileApi::ENDPOINT_URL . '/' . $this->projectId]);
         $this->invokeMethod($this->object, 'sendRequest', ['context/html', $requestData, 'get']);
@@ -1155,9 +1156,6 @@ class FileApiTest extends ApiTestAbstract
 
     /**
      * @covers \Smartling\File\FileApi::readFile
-     *
-     * @expectedException \Smartling\Exceptions\SmartlingApiException
-     * @expectedExceptionMessage File unexisted was not able to be read.
      */
     public function testFailedReadFile()
     {
@@ -1173,6 +1171,8 @@ class FileApiTest extends ApiTestAbstract
 
         $stream = $this->invokeMethod($fileApi, 'readFile', [$invalidFilePath]);
 
+        $this->expectException(SmartlingApiException::class);
+        $this->expectExceptionMessage('File unexisted was not able to be read.');
         $this->assertEquals('stream', \get_resource_type($stream));
     }
 

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Smartling\Tests\Unit;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Smartling\File\FileApi;
 use Smartling\File\Params\DownloadFileParameters;
 use Smartling\File\Params\DownloadMultipleFilesParameters;
@@ -41,7 +42,7 @@ class FileApiTest extends ApiTestAbstract
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prepareHttpClientMock();
         $this->prepareAuthProviderMock();
@@ -1141,7 +1142,7 @@ class FileApiTest extends ApiTestAbstract
         $validFilePath = './tests/resources/test.xml';
 
         /**
-         * @var \PHPUnit_Framework_MockObject_MockObject|\Smartling\File\FileApi
+         * @var \MockObject|FileApi
          */
         $fileApi = $this->getMockBuilder('Smartling\\File\\FileApi')
             ->setConstructorArgs([$this->projectId, $this->client])
@@ -1164,7 +1165,7 @@ class FileApiTest extends ApiTestAbstract
         $invalidFilePath = 'unexisted';
 
         /**
-         * @var \PHPUnit_Framework_MockObject_MockObject|\Smartling\File\FileApi
+         * @var MockObject|FileApi
          */
         $fileApi = $this->getMockBuilder('Smartling\\File\\FileApi')
             ->setConstructorArgs([$this->projectId, $this->client])

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -122,7 +122,7 @@ class FileApiTest extends ApiTestAbstract
                     ],
                     [
                         'name' => 'smartling.client_lib_id',
-                        'contents' => '{"client":"smartling-api-sdk-php","version":"3.9.1"}',
+                        'contents' => '{"client":"smartling-api-sdk-php","version":"4.0.0"}',
                     ],
                     [
                         'name' => 'localeIdsToAuthorize[]',
@@ -221,11 +221,7 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testDownloadFile($options, $locale, $expected_translated_file)
     {
-        $this->prepareClientResponseMock(false);
-
-        $this->responseMock->expects($this->any())
-            ->method('getBody')
-            ->willReturn($expected_translated_file);
+        $this->responseMock = $this->getResponse($expected_translated_file);
 
         $endpointUrl = \vsprintf(
             '%s/%s/locales/%s/file',
@@ -453,17 +449,11 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testLastModifiedInvalidResponseNoDataFoundNoItems()
     {
-        $this->prepareClientResponseMock(false);
+        $this->responseMock = $this->getResponse('{"response":{"code":"SUCCESS","messages":[], "data":{}}}');
 
         $this->client->expects($this->once())
             ->method('request')
             ->willReturn($this->responseMock);
-
-        $response = '{"response":{"code":"SUCCESS","messages":[], "data":{}}}';
-
-        $this->responseMock->expects(self::any())
-              ->method('getBody')
-              ->willReturn($response);
 
         $this->expectException(SmartlingApiException::class);
         $this->expectErrorMessage('No data found for file test.xml.');
@@ -475,17 +465,11 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testLastModifiedInvalidResponseNoDataFoundItemsNotArray()
     {
-        $this->prepareClientResponseMock(false);
+        $this->responseMock = $this->getResponse('{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": "not_array"}}}');
 
         $this->client->expects($this->once())
             ->method('request')
             ->willReturn($this->responseMock);
-
-        $response = '{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": "not_array"}}}';
-
-        $this->responseMock->expects(self::any())
-            ->method('getBody')
-            ->willReturn($response);
 
         $this->expectException(SmartlingApiException::class);
         $this->expectExceptionMessage('No data found for file test.xml.');
@@ -497,17 +481,11 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testLastModifiedInvalidResponseCantParseFormattedTimeString()
     {
-        $this->prepareClientResponseMock(false);
+        $this->responseMock = $this->getResponse('{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test","lastModified": "test"}]}}}');
 
         $this->client->expects($this->once())
             ->method('request')
             ->willReturn($this->responseMock);
-
-        $response = '{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test","lastModified": "test"}]}}}';
-
-        $this->responseMock->expects(self::any())
-            ->method('getBody')
-            ->willReturn($response);
 
         $this->expectException(SmartlingApiException::class);
         $this->expectExceptionMessage("Can't parse formatted time string: test.");
@@ -520,17 +498,11 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testLastModifiedInvalidResponseLastModifiedIsNotSet()
     {
-        $this->prepareClientResponseMock(false);
+        $this->responseMock = $this->getResponse('{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test"}]}}}');
 
         $this->client->expects($this->once())
             ->method('request')
             ->willReturn($this->responseMock);
-
-        $response = '{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test"}]}}}';
-
-        $this->responseMock->expects(self::any())
-            ->method('getBody')
-            ->willReturn($response);
 
         $this->expectException(SmartlingApiException::class);
         $this->expectExceptionMessage('Property "lastModified" is not found.');
@@ -542,17 +514,11 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testLastModifiedTimeZone()
     {
-        $this->prepareClientResponseMock(false);
+        $this->responseMock = $this->getResponse('{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test","lastModified": "2018-01-01T00:00:00Z"}]}}}');
 
         $this->client->expects($this->exactly(2))
             ->method('request')
             ->willReturn($this->responseMock);
-
-        $response = '{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test","lastModified": "2018-01-01T00:00:00Z"}]}}}';
-
-        $this->responseMock->expects(self::any())
-            ->method('getBody')
-            ->willReturn($response);
 
         \date_default_timezone_set('UTC');
         $result_default_utc = $this->object->lastModified('test.xml');
@@ -580,7 +546,7 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testLastModified()
     {
-        $this->prepareClientResponseMock(false);
+        $this->responseMock = $this->getResponse('{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test","lastModified": "1970-01-01T00:00:00Z"}]}}}');
         $endpointUrl = \vsprintf(
             '%s/%s/file/last-modified',
             [
@@ -605,12 +571,6 @@ class FileApiTest extends ApiTestAbstract
                 ],
             ])
             ->willReturn($this->responseMock);
-
-        $response = '{"response":{"code":"SUCCESS","messages":[], "data":{"totalCount":1629,"items": [{"localId": "locale-test","lastModified": "1970-01-01T00:00:00Z"}]}}}';
-
-        $this->responseMock->expects(self::any())
-            ->method('getBody')
-            ->willReturn($response);
 
         $this->object->lastModified('test.xml');
     }
@@ -757,14 +717,7 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testValidationErrorSendRequest()
     {
-        $this->prepareClientResponseMock(false);
-
-        $this->responseMock->expects($this->any())
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $this->responseMock->expects($this->any())
-            ->method('getBody')
-            ->willReturn($this->responseWithException);
+        $this->responseMock = $this->getResponse($this->responseWithException, 400);
 
         $endpointUrl = \vsprintf(
             '%s/%s/context/html',
@@ -801,14 +754,7 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testBadJsonFormatSendRequest()
     {
-        $this->prepareClientResponseMock(false);
-
-        $this->responseMock->expects($this->any())
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $this->responseMock->expects($this->any())
-            ->method('getBody')
-            ->willReturn(\rtrim($this->responseWithException, '}'));
+        $this->responseMock = $this->getResponse(\rtrim($this->responseWithException, '}'), 400);
 
         $endpointUrl = \vsprintf(
             '%s/%s/context/html',
@@ -846,14 +792,7 @@ class FileApiTest extends ApiTestAbstract
      */
     public function testBadJsonFormatInErrorMessageSendRequest()
     {
-        $this->prepareClientResponseMock(false);
-
-        $this->responseMock->expects($this->any())
-            ->method('getStatusCode')
-            ->willReturn(401);
-        $this->responseMock->expects($this->any())
-            ->method('getBody')
-            ->willReturn(\rtrim($this->responseWithException, '}'));
+        $this->responseMock = $this->getResponse(\rtrim($this->responseWithException, '}'), 400);
 
         $endpointUrl = \vsprintf(
             '%s/%s/context/html',
@@ -1143,7 +1082,7 @@ class FileApiTest extends ApiTestAbstract
         $validFilePath = './tests/resources/test.xml';
 
         /**
-         * @var \MockObject|FileApi
+         * @var MockObject|FileApi
          */
         $fileApi = $this->getMockBuilder('Smartling\\File\\FileApi')
             ->setConstructorArgs([$this->projectId, $this->client])
@@ -1169,10 +1108,11 @@ class FileApiTest extends ApiTestAbstract
             ->setConstructorArgs([$this->projectId, $this->client])
             ->getMock();
 
-        $stream = $this->invokeMethod($fileApi, 'readFile', [$invalidFilePath]);
-
         $this->expectException(SmartlingApiException::class);
         $this->expectExceptionMessage('File unexisted was not able to be read.');
+
+        $stream = $this->invokeMethod($fileApi, 'readFile', [$invalidFilePath]);
+
         $this->assertEquals('stream', \get_resource_type($stream));
     }
 
@@ -1182,30 +1122,7 @@ class FileApiTest extends ApiTestAbstract
      * It should not throw "Bad response format" exception.
      */
     public function testAcceptResponse() {
-        $this->prepareClientResponseMock();
-        $responseMock = $this->getMockBuilder('Guzzle\Message\ResponseInterface')
-            ->setMethods(
-                \array_merge(
-                    self::$responseInterfaceMethods,
-                    self::$messageInterfaceMethods
-                )
-            )
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $responseMock->expects(self::any())
-            ->method('getStatusCode')
-            ->willReturn(202);
-
-        $responseMock->expects(self::any())
-            ->method('getBody')
-            ->willReturn($this->responseAsync);
-
-        $responseMock->expects(self::any())
-            ->method('json')
-            ->willReturn(
-                \json_decode($this->responseAsync, true)
-            );
+        $responseMock = $this->getResponse($this->responseAsync, 202);
 
         $this->client->expects(self::once())
             ->method('request')
@@ -1214,5 +1131,4 @@ class FileApiTest extends ApiTestAbstract
         // Just random api call to mock async response of 'send' method.
         $this->object->renameFile('test.xml', 'new_test.xml');
     }
-
 }

--- a/tests/unit/JobsApiTest.php
+++ b/tests/unit/JobsApiTest.php
@@ -495,12 +495,10 @@ class JobsApiTest extends ApiTestAbstract
         $this->object->checkAsynchronousProcessingStatus($jobId, $processId);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Callback method 'TEST' is not allowed. Allowed methods are: GET, POST.
-     */
     public function testCreateJobParametersSetCallbackMethodValidation()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Callback method 'TEST' is not allowed. Allowed methods are: GET, POST.");
         (new CreateJobParameters())->setCallbackMethod("TEST");
     }
 }

--- a/tests/unit/JobsApiTest.php
+++ b/tests/unit/JobsApiTest.php
@@ -29,7 +29,7 @@ class JobsApiTest extends ApiTestAbstract
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareJobsApiMock();

--- a/tests/unit/ProgressTrackerApiTest.php
+++ b/tests/unit/ProgressTrackerApiTest.php
@@ -24,7 +24,7 @@ class ProgressTrackerApiTest extends ApiTestAbstract
             ]
         );
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('get', $endpointUrl, [
                 'headers' => [
@@ -67,7 +67,7 @@ class ProgressTrackerApiTest extends ApiTestAbstract
         $params->setTtl($ttl);
         $params->setData($data);
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('post', $endpointUrl, [
                 'headers' => [
@@ -107,7 +107,7 @@ class ProgressTrackerApiTest extends ApiTestAbstract
             ]
         );
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('delete', $endpointUrl, [
                 'headers' => [
@@ -152,7 +152,7 @@ class ProgressTrackerApiTest extends ApiTestAbstract
         $params->setTtl($ttl);
         $params->setData($data);
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('put', $endpointUrl, [
                 'headers' => [

--- a/tests/unit/ProgressTrackerApiTest.php
+++ b/tests/unit/ProgressTrackerApiTest.php
@@ -177,7 +177,7 @@ class ProgressTrackerApiTest extends ApiTestAbstract
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareProgressTrackerApiMock();

--- a/tests/unit/ProjectApiTest.php
+++ b/tests/unit/ProjectApiTest.php
@@ -44,7 +44,7 @@ class ProjectApiTest extends ApiTestAbstract
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareProjectApiMock();

--- a/tests/unit/ProjectApiTest.php
+++ b/tests/unit/ProjectApiTest.php
@@ -22,7 +22,7 @@ class ProjectApiTest extends ApiTestAbstract
             ]
         );
 
-        $this->client->expects($this->any())
+        $this->client->expects($this->once())
             ->method('request')
             ->with('get', $endpointUrl, [
                 'headers' => [

--- a/tests/unit/TranslationRequestsApiTest.php
+++ b/tests/unit/TranslationRequestsApiTest.php
@@ -64,7 +64,6 @@ class TranslationRequestsApiTest extends ApiTestAbstract
      */
     public function testCreateTranslationRequest()
     {
-
         $createParams = (new CreateTranslationRequestParams())
             ->setOriginalAssetKey(['a' => '1'])
             ->setTitle('Submission 1')
@@ -96,7 +95,7 @@ class TranslationRequestsApiTest extends ApiTestAbstract
             ]
         );
 
-        $this->mockClientResponse(200, $testRawResponse);
+        $this->responseMock = $this->getResponse($testRawResponse);
 
         $testExpectedResponse = \json_decode($testRawResponse, true)['response']['data'];
 
@@ -130,7 +129,6 @@ class TranslationRequestsApiTest extends ApiTestAbstract
      */
     public function testUpdateTranslationRequest()
     {
-
         $translationRequestUid = '8264fd9133d3';
 
         $updateParams = (new UpdateTranslationRequestParams())->setTitle('Submission 2');
@@ -160,7 +158,7 @@ class TranslationRequestsApiTest extends ApiTestAbstract
             ]
         );
 
-        $this->mockClientResponse(200, $testRawResponse);
+        $this->responseMock = $this->getResponse($testRawResponse);
 
         $testExpectedResponse = \json_decode($testRawResponse, true)['response']['data'];
 
@@ -194,7 +192,6 @@ class TranslationRequestsApiTest extends ApiTestAbstract
      */
     public function testGetTranslationRequest()
     {
-
         $translationRequestUid = '8264fd9133d3';
 
         $testRawResponse = \json_encode(
@@ -222,7 +219,7 @@ class TranslationRequestsApiTest extends ApiTestAbstract
             ]
         );
 
-        $this->mockClientResponse(200, $testRawResponse);
+        $this->responseMock =  $this->getResponse($testRawResponse);
 
         $testExpectedResponse = \json_decode($testRawResponse, true)['response']['data'];
 
@@ -400,7 +397,7 @@ class TranslationRequestsApiTest extends ApiTestAbstract
     {
         $testRawResponse = \json_encode($rawResponse);
 
-        $this->mockClientResponse(200, $testRawResponse);
+        $this->responseMock = $this->getResponse($testRawResponse);
 
         $testExpectedResponse = $rawResponse['response']['data'];
 

--- a/tests/unit/TranslationRequestsApiTest.php
+++ b/tests/unit/TranslationRequestsApiTest.php
@@ -14,7 +14,7 @@ class TranslationRequestsApiTest extends ApiTestAbstract
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareTranslationRequestsApiMock();


### PR DESCRIPTION
guzzle 7 requires at least php 7.2, so I've updated the dependency to php 7.4. For tests to work, I had to update to phpunit 8. Some tests were broken, so I've introduced fixes.