### PR TITLE
add filename for multipart file uploads in file api (CON-1092)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "smartling/api-sdk-php",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "type": "library",
   "description": "PHP library to communicate with SmartlingAPI",
   "keywords": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "594f8496d79f415917b7567d68e0a195",
+    "content-hash": "06a23eb2f7ab42693669ea524cecb36e",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -966,12 +966,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "21481a5c97e8332f7279e31219c32faa2da21c79"
+                "reference": "6baa6f8bd7ec9986a6fd8a40a527be94bf78411d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/21481a5c97e8332f7279e31219c32faa2da21c79",
-                "reference": "21481a5c97e8332f7279e31219c32faa2da21c79",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/6baa6f8bd7ec9986a6fd8a40a527be94bf78411d",
+                "reference": "6baa6f8bd7ec9986a6fd8a40a527be94bf78411d",
                 "shasum": ""
             },
             "require": {
@@ -1016,7 +1016,7 @@
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
                 "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
             },
-            "time": "2021-12-27T22:36:43+00:00"
+            "time": "2022-03-29T20:08:34+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1065,7 +1065,7 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.x"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
             "time": "2022-03-15T21:29:03+00:00"
         },

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -21,10 +21,9 @@ use Smartling\Logger\DevNullLogger;
  */
 abstract class BaseApiAbstract
 {
-
     const CLIENT_LIB_ID_SDK = 'smartling-api-sdk-php';
 
-    const CLIENT_LIB_ID_VERSION = '4.0.0';
+    const CLIENT_LIB_ID_VERSION = '4.0.2';
 
     const CLIENT_USER_AGENT_EXTENSION = '(no extensions)';
 
@@ -558,5 +557,4 @@ abstract class BaseApiAbstract
             }
         }
     }
-
 }

--- a/src/Context/Params/UploadContextParameters.php
+++ b/src/Context/Params/UploadContextParameters.php
@@ -10,18 +10,6 @@ use Smartling\Parameters\BaseParameters;
  */
 class UploadContextParameters extends BaseParameters
 {
-
-    /**
-     * @param $contextFileUri
-     *
-     * @deprecated since version 3.5.0, to be removed in 4.0.0.
-     * Use UploadContextParameters::setContent() instead.
-     */
-    public function setContextFileUri($contextFileUri)
-    {
-        $this->set('content', $contextFileUri);
-    }
-
     public function setContent($contextFileUri)
     {
         $this->set('content', $contextFileUri);
@@ -36,5 +24,4 @@ class UploadContextParameters extends BaseParameters
     {
         $this->set('matchParams', \json_encode($params->exportToArray()));
     }
-
 }

--- a/src/Exceptions/SmartlingApiException.php
+++ b/src/Exceptions/SmartlingApiException.php
@@ -2,7 +2,7 @@
 
 namespace Smartling\Exceptions;
 
-use Exception;
+use GuzzleHttp\Exception\ClientException;
 
 /**
  * Class SmartlingApiException
@@ -91,7 +91,7 @@ class SmartlingApiException extends \Exception
     public function formatErrors($title = '')
     {
         $errorsStr = PHP_EOL;
-        
+
         foreach ($this->errors as $k => $error) {
             $details = [];
             
@@ -123,7 +123,12 @@ class SmartlingApiException extends \Exception
                 $errorsStr,
             ]
         );
-        
+
+        $previous = $this->getPrevious();
+        if ($previous instanceof ClientException) {
+            $output .= PHP_EOL . 'Guzzle::ClientException: ' . $previous->getResponse()->getBody();
+        }
+
         return $output;
     }
 }

--- a/src/Exceptions/SmartlingApiException.php
+++ b/src/Exceptions/SmartlingApiException.php
@@ -126,7 +126,7 @@ class SmartlingApiException extends \Exception
 
         $previous = $this->getPrevious();
         if ($previous instanceof ClientException) {
-            $output .= PHP_EOL . 'Guzzle::ClientException: ' . $previous->getResponse()->getBody();
+            $output .= PHP_EOL . ClientException::class . ': ' . $previous->getResponse()->getBody();
         }
 
         return $output;

--- a/src/File/FileApi.php
+++ b/src/File/FileApi.php
@@ -20,7 +20,7 @@ use Smartling\File\Params\UploadFileParameters;
  */
 class FileApi extends BaseApiAbstract
 {
-
+    public const FILE_NAME_NOT_SET = 'filename_not_set';
     const ENDPOINT_URL = 'https://api.smartling.com/files-api/v2/projects';
 
     /**
@@ -51,7 +51,7 @@ class FileApi extends BaseApiAbstract
             foreach ($opts['multipart'] as &$data) {
                 if ($data['name'] === 'file') {
                     $data['contents'] = $this->readFile($data['contents']);
-                    $data['filename'] = array_key_exists('name', $opts) ? $opts['name'] : 'unknown';
+                    $data['filename'] = array_key_exists('name', $opts) ? $opts['name'] : self::FILE_NAME_NOT_SET;
                 }
             }
         }

--- a/src/File/FileApi.php
+++ b/src/File/FileApi.php
@@ -46,12 +46,12 @@ class FileApi extends BaseApiAbstract
      */
     protected function processBodyOptions($requestData = []) {
         $opts = parent::processBodyOptions($requestData);
-        $key = 'file';
 
         if (!empty($opts['multipart'])) {
             foreach ($opts['multipart'] as &$data) {
-                if ($data['name'] == $key) {
+                if ($data['name'] === 'file') {
                     $data['contents'] = $this->readFile($data['contents']);
+                    $data['filename'] = array_key_exists('name', $opts) ? $opts['name'] : 'unknown';
                 }
             }
         }

--- a/tests/functional/FileApiFunctionalTest.php
+++ b/tests/functional/FileApiFunctionalTest.php
@@ -16,7 +16,6 @@ use Smartling\File\Params\ListFilesParameters;
  */
 class FileApiFunctionalTest extends TestCase
 {
-
     /**
      * @var FileApi
      */
@@ -31,6 +30,8 @@ class FileApiFunctionalTest extends TestCase
      * @var string
      */
     const NEW_FILE_NAME = 'new_test.xml';
+
+    private const STREAM_UPLOAD_FILE_NAME = 'test_stream_upload.json';
 
     /**
      * @var string
@@ -69,7 +70,7 @@ class FileApiFunctionalTest extends TestCase
         $authProvider = AuthTokenProvider::create(\getenv('user_id'), \getenv('user_key'));
         $fileApi = FileApi::create($authProvider, \getenv('project_id'));
 
-        foreach ([self::FILE_NAME, self::NEW_FILE_NAME] as $file) {
+        foreach ([self::FILE_NAME, self::NEW_FILE_NAME, self::STREAM_UPLOAD_FILE_NAME] as $file) {
             try {
                 $fileApi->deleteFile($file);
             }
@@ -118,6 +119,15 @@ class FileApiFunctionalTest extends TestCase
             $this->assertArrayHasKey('overWritten', $result);
         }
         catch (SmartlingApiException $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    public function testFileApiUploadDataStream() {
+        try {
+            $result = $this->fileApi->uploadFile('data://text/plain;base64,' . base64_encode(file_get_contents(__DIR__ . '/../resources/memoryPath.json')), self::STREAM_UPLOAD_FILE_NAME, 'json');
+            $this->assertArrayHasKey('wordCount', $result);
+        } catch (SmartlingApiException $e) {
             $this->fail($e->getMessage());
         }
     }

--- a/tests/resources/memoryPath.json
+++ b/tests/resources/memoryPath.json
@@ -1,0 +1,20 @@
+{
+  "smartling": {
+    "translate_paths": {
+      "path": "*\/translation",
+      "key": "{*}\/translation",
+      "instruction": "*\/translation-note"
+    },
+    "string_format": "icu",
+    "variants_enabled": "true",
+    "feature_branch": "translations_For_huge_file_browse",
+    "repository": "sf-ui-browse",
+    "owner": "shared",
+    "file_path": "translations\/stores\/browse\/filtering\/messages.po",
+    "base_branch": "main"
+  },
+  "someKey": {
+    "translation": "TestTranslation",
+    "translation-note": []
+  }
+}

--- a/tests/unit/BaseApiAbstractTest.php
+++ b/tests/unit/BaseApiAbstractTest.php
@@ -25,7 +25,7 @@ class BaseApiAbstractTest extends ApiTestAbstract
         $instance = FileApi::create($this->authProvider, 'test');
         $http_client = $this->invokeMethod($instance, 'getHttpClient');
 
-        $this->assertEquals('smartling-api-sdk-php/4.0.0 (no extensions) GuzzleHttp/7', $http_client->getConfig()['headers']['User-Agent']);
+        $this->assertEquals('smartling-api-sdk-php/4.0.2 (no extensions) GuzzleHttp/7', $http_client->getConfig()['headers']['User-Agent']);
     }
 
     /**

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -138,7 +138,7 @@ class FileApiTest extends ApiTestAbstract
                         [
                             'name' => 'file',
                             'contents' => $this->streamPlaceholder,
-                            'filename' => 'unknown'
+                            'filename' => FileApi::FILE_NAME_NOT_SET
                         ],
                         [
                             'name' => 'fileUri',
@@ -915,7 +915,7 @@ class FileApiTest extends ApiTestAbstract
                       [
                         'name' => 'file',
                         'contents' => $this->streamPlaceholder,
-                        'filename' => 'unknown',
+                        'filename' => FileApi::FILE_NAME_NOT_SET,
                       ],
                     ],
                 ],
@@ -1060,7 +1060,7 @@ class FileApiTest extends ApiTestAbstract
                     [
                         'name' => 'file',
                         'contents' => $this->streamPlaceholder,
-                        'filename' => 'unknown'
+                        'filename' => FileApi::FILE_NAME_NOT_SET
                     ],
                     [
                         'name' => 'translationState',

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -122,7 +122,7 @@ class FileApiTest extends ApiTestAbstract
                     ],
                     [
                         'name' => 'smartling.client_lib_id',
-                        'contents' => '{"client":"smartling-api-sdk-php","version":"4.0.0"}',
+                        'contents' => '{"client":"smartling-api-sdk-php","version":"4.0.2"}',
                     ],
                     [
                         'name' => 'localeIdsToAuthorize[]',


### PR DESCRIPTION
I'm not sure this is strictly necessary, but let's discuss. File api uploads file if this information is not present when uploading file.