### PR TITLE
Php8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "smartling/api-sdk-php",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "type": "library",
   "description": "PHP library to communicate with SmartlingAPI",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
   "authors": [],
   "require": {
     "psr/log": "^1.0.0 || ^3.0.0",
-    "php": ">=7.3",
+    "php": "^7.3 || ^8.0",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "~7"
+    "guzzlehttp/guzzle": "^6.0.0 || ^7.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b46c31e47f6e8db38ffec25975cb7f5e",
+    "content-hash": "b5a3ce3b5bd27c8416f41293d2982006",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6cc206bcfcd5017ccc15a9d6694e42b",
+    "content-hash": "b46c31e47f6e8db38ffec25975cb7f5e",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2373,7 +2373,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -7,7 +7,6 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -413,7 +413,7 @@ abstract class BaseApiAbstract
     /**
      * @throws SmartlingApiException
      */
-    private function processError(ResponseInterface $response): void
+    private function processError(Response $response): void
     {
         try {
             $json = \json_decode($response->getBody(), true);

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -5,8 +5,8 @@ namespace Smartling;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
@@ -378,10 +378,10 @@ abstract class BaseApiAbstract
     }
 
     /**
-     * @param Response $response
+     * @param ResponseInterface $response
      * @throws SmartlingApiException
      */
-    private function checkAuthenticationError(Response $response)
+    private function checkAuthenticationError(ResponseInterface $response)
     {
         //Special handling for 401 error - authentication error => expire token
         if (401 === (int)$response->getStatusCode()) {
@@ -398,10 +398,10 @@ abstract class BaseApiAbstract
     }
 
     /**
-     * @param Response $response
+     * @param ResponseInterface $response
      * @throws SmartlingApiException
      */
-    private function processErrors(Response $response)
+    private function processErrors(ResponseInterface $response)
     {
         // Catch all errors from Smartling and throw appropriate exception.
         if (400 <= (int)$response->getStatusCode()) {
@@ -412,7 +412,7 @@ abstract class BaseApiAbstract
     /**
      * @throws SmartlingApiException
      */
-    private function processError(Response $response): void
+    private function processError(ResponseInterface $response): void
     {
         try {
             $json = \json_decode($response->getBody(), true);

--- a/src/BaseApiAbstract.php
+++ b/src/BaseApiAbstract.php
@@ -23,7 +23,7 @@ abstract class BaseApiAbstract
 {
     const CLIENT_LIB_ID_SDK = 'smartling-api-sdk-php';
 
-    const CLIENT_LIB_ID_VERSION = '4.0.4';
+    const CLIENT_LIB_ID_VERSION = '4.0.5';
 
     const CLIENT_USER_AGENT_EXTENSION = '(no extensions)';
 

--- a/tests/unit/BaseApiAbstractTest.php
+++ b/tests/unit/BaseApiAbstractTest.php
@@ -25,7 +25,7 @@ class BaseApiAbstractTest extends ApiTestAbstract
         $instance = FileApi::create($this->authProvider, 'test');
         $http_client = $this->invokeMethod($instance, 'getHttpClient');
 
-        $this->assertEquals('smartling-api-sdk-php/4.0.4 (no extensions) GuzzleHttp/7', $http_client->getConfig()['headers']['User-Agent']);
+        $this->assertEquals('smartling-api-sdk-php/4.0.5 (no extensions) GuzzleHttp/7', $http_client->getConfig()['headers']['User-Agent']);
     }
 
     /**

--- a/tests/unit/FileApiTest.php
+++ b/tests/unit/FileApiTest.php
@@ -125,7 +125,7 @@ class FileApiTest extends ApiTestAbstract
                         ],
                         [
                             'name' => 'smartling.client_lib_id',
-                            'contents' => '{"client":"smartling-api-sdk-php","version":"4.0.4"}',
+                            'contents' => '{"client":"smartling-api-sdk-php","version":"4.0.5"}',
                         ],
                         [
                             'name' => 'localeIdsToAuthorize[]',


### PR DESCRIPTION
Let's make sdk compatible with guzzle 6 and 7 at the same time. Tests are passed with G6 and G7. I don't want to have different branches for Drupal 9 and Drupal 10 support.

Seems like we do not use any specific features/calls/methods that are backward non compatible in G6 and G7.